### PR TITLE
kernel, syscall: remove the legacy int 80h syscall method

### DIFF
--- a/src/aero_kernel/src/arch/x86_64/interrupts/idt.rs
+++ b/src/aero_kernel/src/arch/x86_64/interrupts/idt.rs
@@ -204,9 +204,6 @@ pub fn init() {
 
         IDT[49].set_function(super::irq::lapic_error);
 
-        IDT[0x80].set_flags(IDTFlags::PRESENT | IDTFlags::RING_3 | IDTFlags::INTERRUPT);
-        IDT[0x80].set_offset(8, crate::syscall::syscall_interrupt_handler as usize);
-
         IDT[IPI_ABORT as usize].set_function(super::ipi::abort);
         IDT[IPI_RESCHEDULE as usize].set_function(super::ipi::reschedule);
 

--- a/src/aero_syscall/src/syscall.rs
+++ b/src/aero_syscall/src/syscall.rs
@@ -1,28 +1,15 @@
 macro define_syscall_fns($(pub fn $sys_fn:ident($a:ident $(,$b:ident $(,$c:ident $(,$d:ident $(,$e:ident $(,$f:ident $(,$g:ident)?)?)?)?)?)?) -> usize;)+) {
     $(
         pub fn $sys_fn(mut $a: usize, $($b: usize, $($c: usize, $($d: usize, $($e: usize, $($f: usize, $($g: usize)?)?)?)?)?)?) -> usize {
-            if $crate::syscall::supports_syscall_sysret() {
-                unsafe {
+            unsafe {
                     asm!(
                         "syscall",
-                        inout("rax") $a,
-                        $(in("rdi") $b, $(in("rsi") $c, $(in("rdx") $d, $(in("r10") $e, $(in("r8") $f,)?)?)?)?)?
-                        out("rcx") _,
-                        out("r11") _,
-                        options(nostack),
-                    );
-             }
-            } else {
-                unsafe {
-                    asm!(
-                        "int 0x80",
                         inout("rax") $a,
                         $(in("rdi") $b, $(in("rsi") $c, $(in("rdx") $d, $(in("r10") $e, $(in("r8") $f, $(in("r9") $g,)?)?)?)?)?)?
                         out("rcx") _,
                         out("r11") _,
                         options(nostack),
                     );
-                }
             }
 
             $a
@@ -39,18 +26,3 @@ define_syscall_fns!(
     pub fn syscall5(a, b, c, d, e, f) -> usize;
     pub fn syscall6(a, b, c, d, e, f, g) -> usize;
 );
-
-/// Returns true if the current CPU supports the `syscall` and
-/// the `sysret` instruction.
-#[inline(always)]
-pub fn supports_syscall_sysret() -> bool {
-    #[cfg(target_pointer_width = "64")]
-    {
-        true
-    }
-
-    #[cfg(not(target_pointer_width = "64"))]
-    {
-        false
-    }
-}


### PR DESCRIPTION
Since aero is advertised as a "modern and experimental" kernel and since the int 80h syscall interface wasn't implemented beyond having a dedicated ISR which would just panic with an "unimplemented" error message, I figured it would be easier to remove the legacy syscall method rather than supporting it.