### PR TITLE
Change contents of tty.rs to not panick if terminal buffer is overflown

### DIFF
--- a/src/aero_kernel/src/drivers/tty.rs
+++ b/src/aero_kernel/src/drivers/tty.rs
@@ -222,7 +222,7 @@ impl INodeInterface for Tty {
         stdin.front_buffer.resize(buffer.len(), 0x00);
         buffer.copy_from_slice(&stdin.front_buffer);
 
-        Ok(size)
+        Ok(core::cmp::min(buffer.len(), stdin.front_buffer.len()))
     }
 
     fn write_at(&self, _offset: usize, buffer: &[u8]) -> fs::Result<usize> {


### PR DESCRIPTION
before it used to look like:
![image](https://user-images.githubusercontent.com/74153455/145001245-021d2c2d-5eba-41d3-8879-db3f1bcabeed.png)

now it looks like this but with "command not found" at the end:
![image](https://user-images.githubusercontent.com/74153455/145001365-58a82743-87be-4902-8e0d-96484915f3dc.png)
