### PR TITLE
Fix the docs link pointing to a wrong directory

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv='refresh' content='0; URL=https://andy-python-programmer.github.io/aero/doc/aero_kernel/index.html' />
+<meta http-equiv='refresh' content='0; URL=https://andy-python-programmer.github.io/aero/aero_kernel/index.html' />


### PR DESCRIPTION
Due to the recent change in build tooling a change was made where Aero documentation was moved from the `doc` sub-directory to the root of docs build tree. The Aero main page still thinks the documentation is in the `doc` sub-directory, and fails to redirect to the right place. This PR fixes that issue.