### PR TITLE
aero_shell: get input using raw tty mode (and support history :^)

### DIFF
--- a/src/aero_kernel/src/drivers/tty.rs
+++ b/src/aero_kernel/src/drivers/tty.rs
@@ -264,8 +264,8 @@ impl INodeInterface for Tty {
 
                 let (rows, cols) = crate::rendy::get_rows_cols();
 
+                winsize.ws_col = (cols - (crate::rendy::X_PAD * 2)) as u16;
                 winsize.ws_row = rows as u16;
-                winsize.ws_col = cols as u16;
 
                 let (xpixel, ypixel) = crate::rendy::get_resolution();
 
@@ -550,6 +550,9 @@ impl vte::Perform for AnsiEscape {
 
         if char == '\n' || char == '\t' {
             crate::rendy::print!("{}", char);
+        } else if char == '\r' {
+            let (_, y) = crate::rendy::get_cursor_position();
+            crate::rendy::set_cursor_position(0, y)
         }
     }
 

--- a/src/aero_kernel/src/rendy.rs
+++ b/src/aero_kernel/src/rendy.rs
@@ -60,7 +60,7 @@ const VGA_FONT_GLYPHS: usize = 256;
 
 /// Constant describing the number of columns padded at the left
 /// and right of the screen.
-const X_PAD: usize = 1;
+pub const X_PAD: usize = 1;
 
 const MARGIN_GRADIENT: usize = 4;
 const DWORD_SIZE: usize = core::mem::size_of::<u32>();

--- a/userland/aero_shell/src/main.rs
+++ b/userland/aero_shell/src/main.rs
@@ -41,7 +41,6 @@ const UWUFETCH_LOGO: &str = r#"
 
 fn repl(history: &mut Vec<String>) -> Result<(), AeroSyscallError> {
     let mut pwd_buffer = [0; 1024];
-    let mut cmd_buffer = [0; 1024];
 
     let pwd_length = sys_getcwd(&mut pwd_buffer)?;
     let pwd = unsafe { core::str::from_utf8_unchecked(&pwd_buffer[0..pwd_length]) };
@@ -50,14 +49,12 @@ fn repl(history: &mut Vec<String>) -> Result<(), AeroSyscallError> {
     let username = hostname_split.next().unwrap_or("root");
     let hostname = hostname_split.next().unwrap_or("aero");
 
-    print!(
+    let prefix = format!(
         "\x1b[1;32m{}@{}\x1b[0m:\x1b[1;34m{}\x1b[0m ",
         username, hostname, pwd
     );
 
-    let cmd_length = sys_read(0, &mut cmd_buffer)?;
-    let cmd_string = unsafe { core::str::from_utf8_unchecked(&cmd_buffer[0..cmd_length]).trim() };
-
+    let cmd_string = readline::readline(&prefix, history)?;
     let mut args = cmd_string.split_whitespace();
 
     if let Some(cmd) = args.next() {
@@ -98,9 +95,7 @@ fn repl(history: &mut Vec<String>) -> Result<(), AeroSyscallError> {
                     println!("{}", entry);
                 }
             }
-            "uwutest" => {
-                let _ = readline::readline()?;
-            }
+
             _ => {
                 let child = sys_fork()?;
 


### PR DESCRIPTION
- [x] Get input using raw tty mode
- [x] Support getting history using up and down arrow keys
- [ ] Support moving the cursor around (which is currently possible but not in non-canonical mode)
- [ ] Support backspace
- [ ] Support backspace at arbitrary cursor location

Signed-off-by: Andy-Python-Programmer <andypythonappdeveloper@gmail.com>