### PR TITLE
Inter-process communication support

### DIFF
--- a/src/aero_kernel/src/syscall/mod.rs
+++ b/src/aero_kernel/src/syscall/mod.rs
@@ -194,8 +194,8 @@ extern "C" fn __inner_syscall(sys: &mut SyscallFrame, stack: &mut RegistersFrame
         SYS_INFO => process::info(b),
         SYS_SIGACTION => process::sigaction(b, c, d, e),
         SYS_CLONE => process::clone(b, c),
-        SYS_IPC_SEND => process::ipc_send(b, c, d, e),
-        SYS_IPC_RECV => process::ipc_recv(b, c, d, e, f),
+        SYS_IPC_SEND => process::ipc_send(b, c, d, e, f),
+        SYS_IPC_RECV => process::ipc_recv(b, c, d, e, f, g),
 
         SYS_READ => fs::read(b, c, d),
         SYS_OPEN => fs::open(b, c, d, e),

--- a/src/aero_kernel/src/syscall/mod.rs
+++ b/src/aero_kernel/src/syscall/mod.rs
@@ -194,6 +194,8 @@ extern "C" fn __inner_syscall(sys: &mut SyscallFrame, stack: &mut RegistersFrame
         SYS_INFO => process::info(b),
         SYS_SIGACTION => process::sigaction(b, c, d, e),
         SYS_CLONE => process::clone(b, c),
+        SYS_IPC_SEND => process::ipc_send(b, c, d, e),
+        SYS_IPC_RECV => process::ipc_recv(b, c, d, e, f),
 
         SYS_READ => fs::read(b, c, d),
         SYS_OPEN => fs::open(b, c, d, e),

--- a/src/aero_kernel/src/syscall/process.rs
+++ b/src/aero_kernel/src/syscall/process.rs
@@ -326,6 +326,8 @@ pub fn ipc_send(
     let msg_id = queue.make_id();
 
     queue.push_back(Message::new(msg_id, current_task.pid(), buf));
+    scheduler.wake_up(target_task);
+
     Ok(msg_id)
 }
 

--- a/src/aero_kernel/src/userland/scheduler/mod.rs
+++ b/src/aero_kernel/src/userland/scheduler/mod.rs
@@ -126,6 +126,11 @@ impl Scheduler {
     pub fn find_task(&self, task_id: TaskId) -> Option<Arc<Task>> {
         self.tasks.find_task(task_id)
     }
+
+    #[inline]
+    pub fn wake_up(&self, task: Arc<Task>) {
+        self.inner.wake_up(task);
+    }
 }
 
 /// Get a reference to the active scheduler.

--- a/src/aero_kernel/src/userland/scheduler/mod.rs
+++ b/src/aero_kernel/src/userland/scheduler/mod.rs
@@ -76,6 +76,11 @@ impl TaskContainer {
     fn register_task(&self, task_id: TaskId, task: Arc<Task>) {
         self.0.lock().insert(task_id, task);
     }
+
+    #[inline]
+    fn find_task(&self, task_id: TaskId) -> Option<Arc<Task>> {
+        self.0.lock().get(&task_id).map(|task| task.clone())
+    }
 }
 
 unsafe impl Send for TaskContainer {}
@@ -115,6 +120,11 @@ impl Scheduler {
     #[inline]
     pub fn current_task(&self) -> Arc<Task> {
         self.inner.current_task()
+    }
+
+    #[inline]
+    pub fn find_task(&self, task_id: TaskId) -> Option<Arc<Task>> {
+        self.tasks.find_task(task_id)
     }
 }
 

--- a/src/aero_kernel/src/userland/task.rs
+++ b/src/aero_kernel/src/userland/task.rs
@@ -166,6 +166,7 @@ impl Zombies {
 
 pub struct Message {
     id: usize,
+    tag: usize,
     from: TaskId,
     data: Vec<u8>,
 }
@@ -177,9 +178,10 @@ pub struct MessageQueue {
 }
 
 impl Message {
-    pub fn new(id: usize, from: TaskId, data: &[u8]) -> Self {
+    pub fn new(id: usize, tag: usize, from: TaskId, data: &[u8]) -> Self {
         Self {
             id,
+            tag,
             from,
             data: Vec::from(data),
         }
@@ -187,6 +189,10 @@ impl Message {
 
     pub fn id(&self) -> usize {
         self.id
+    }
+
+    pub fn tag(&self) -> usize {
+        self.tag
     }
 
     pub fn from(&self) -> TaskId {

--- a/src/aero_kernel/src/userland/task.rs
+++ b/src/aero_kernel/src/userland/task.rs
@@ -233,12 +233,15 @@ impl MessageQueue {
         self.queue.lock().pop_front()
     }
 
-    pub fn wait_for_message(&self) -> SignalResult<Message> {
-        let mut queue = self
-            .block
+    pub fn peek_length(&self) -> Option<usize> {
+        self.queue.lock().front().map(|msg| msg.data().len())
+    }
+
+    pub fn wait_for_message(&self) -> SignalResult<()> {
+        self.block
             .block_on(&self.queue, |queue| !queue.is_empty())?;
 
-        Ok(queue.pop_front().unwrap())
+        Ok(())
     }
 }
 

--- a/src/aero_syscall/src/consts.rs
+++ b/src/aero_syscall/src/consts.rs
@@ -63,6 +63,8 @@ pub const SYS_SIGPROCMASK: usize = 41;
 pub const SYS_DUP: usize = 42;
 pub const SYS_FCNTL: usize = 43;
 pub const SYS_DUP2: usize = 44;
+pub const SYS_IPC_SEND: usize = 45;
+pub const SYS_IPC_RECV: usize = 46;
 
 // fcntl constants:
 pub const F_GETFD: usize = 3;

--- a/src/aero_syscall/src/lib.rs
+++ b/src/aero_syscall/src/lib.rs
@@ -862,12 +862,14 @@ bitflags::bitflags! {
 
 pub fn sys_ipc_send(
     pid: usize,
+    tag: usize,
     buf: &[u8],
     flags: IpcSendFlags,
 ) -> Result<usize, AeroSyscallError> {
-    let value = syscall4(
+    let value = syscall5(
         prelude::SYS_IPC_SEND,
         pid,
+        tag,
         buf.as_ptr() as _,
         buf.len(),
         flags.bits() as _,
@@ -879,14 +881,16 @@ pub fn sys_ipc_recv(
     buf: &mut [u8],
     pid: &mut usize,
     length: &mut usize,
+    tag: &mut usize,
     flags: IpcRecvFlags,
 ) -> Result<usize, AeroSyscallError> {
-    let value = syscall5(
+    let value = syscall6(
         prelude::SYS_IPC_RECV,
         buf.as_mut_ptr() as _,
         buf.len(),
         pid as *mut usize as _,
         length as *mut usize as _,
+        tag as *mut usize as _,
         flags.bits() as _,
     );
     isize_as_syscall_result(value as _)

--- a/userland/Cargo.lock
+++ b/userland/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "aero_ipc"
+version = "0.1.0"
+dependencies = [
+ "aero_syscall",
+ "postcard",
+ "serde",
+ "std",
+]
+
+[[package]]
 name = "aero_shell"
 version = "0.1.0"
 dependencies = [
@@ -18,18 +28,139 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+dependencies = [
+ "critical-section",
+ "riscv-target",
+]
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cortex-m"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
+dependencies = [
+ "bare-metal 0.2.5",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "critical-section"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if",
+ "cortex-m",
+ "riscv",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "init"
 version = "0.1.0"
 dependencies = [
+ "aero_ipc",
  "aero_syscall",
  "std",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "linked_list_allocator"
@@ -50,6 +181,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
+name = "postcard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
+dependencies = [
+ "heapless",
+ "postcard-cobs",
+ "serde",
+]
+
+[[package]]
+name = "postcard-cobs"
+version = "0.1.5-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +237,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "spin"
@@ -90,6 +341,12 @@ checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "std"
@@ -132,4 +389,25 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+dependencies = [
+ "vcell",
 ]

--- a/userland/aero_ipc/Cargo.toml
+++ b/userland/aero_ipc/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
-name = "init"
+name = "aero_ipc"
 version = "0.1.0"
 authors = ["czapek1337 <czapek1337@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-aero_ipc = { path = "../aero_ipc" }
 aero_syscall = { path = "../../src/aero_syscall" }
 std = { path = "../aero_std" }
+postcard = "0.7.3"
+
+[dependencies.serde]
+version = "1.0.136"
+default-features = false

--- a/userland/aero_ipc/src/event_loop.rs
+++ b/userland/aero_ipc/src/event_loop.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2021-2022 The Aero Project Developers.
+ *
+ * This file is part of The Aero Project.
+ *
+ * Aero is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Aero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Aero. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use aero_syscall::*;
+
+use crate::message::IncomingMessage;
+
+pub struct EventLoop {
+    buffer: Vec<u8>,
+}
+
+impl EventLoop {
+    pub fn new() -> Self {
+        let mut buffer = Vec::new();
+
+        buffer.resize(1024, 0);
+
+        Self { buffer }
+    }
+
+    pub fn receive_with_flags(
+        &mut self,
+        flags: IpcRecvFlags,
+    ) -> Result<IncomingMessage, AeroSyscallError> {
+        let mut pid = 0;
+        let mut length = 0;
+        let mut tag = 0;
+
+        match sys_ipc_recv(&mut self.buffer, &mut pid, &mut length, &mut tag, flags) {
+            Ok(id) => Ok(IncomingMessage::new(id, pid, tag, &self.buffer[0..length])),
+            Err(AeroSyscallError::E2BIG) => {
+                self.buffer.resize(length, 0);
+                self.receive_with_flags(flags)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn receive(&mut self) -> Result<IncomingMessage, AeroSyscallError> {
+        self.receive_with_flags(IpcRecvFlags::empty())
+    }
+}

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2021-2022 The Aero Project Developers.
+ *
+ * This file is part of The Aero Project.
+ *
+ * Aero is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Aero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Aero. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+pub mod event_loop;
+pub mod message;

--- a/userland/aero_ipc/src/message.rs
+++ b/userland/aero_ipc/src/message.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2021-2022 The Aero Project Developers.
+ *
+ * This file is part of The Aero Project.
+ *
+ * Aero is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Aero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Aero. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#[derive(Debug)]
+pub struct IncomingMessage<'a> {
+    id: usize,
+    pid: usize,
+    tag: usize,
+    data: &'a [u8],
+}
+
+impl<'a> IncomingMessage<'a> {
+    pub(crate) fn new(id: usize, pid: usize, tag: usize, data: &'a [u8]) -> Self {
+        Self { id, pid, tag, data }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id
+    }
+
+    pub fn pid(&self) -> usize {
+        self.pid
+    }
+
+    pub fn tag(&self) -> usize {
+        self.tag
+    }
+
+    pub fn data(&self) -> &[u8] {
+        self.data
+    }
+}

--- a/userland/aero_shell/src/main.rs
+++ b/userland/aero_shell/src/main.rs
@@ -138,10 +138,6 @@ fn repl(history: &mut Vec<String>) -> Result<(), AeroSyscallError> {
                 uwutest()?;
             }
 
-            "ipctest" => {
-                ipc_test()?;
-            }
-
             "pid" => {
                 println!("{}", sys_getpid()?);
             }
@@ -320,40 +316,6 @@ fn uwutest() -> Result<(), AeroSyscallError> {
 
     println!("uwutest: successfully bound to {:?}", SOCKET_PATH);
     list_directory(".")?;
-
-    Ok(())
-}
-
-fn ipc_test() -> Result<(), AeroSyscallError> {
-    let parent_pid = sys_getpid()?;
-    let child_pid = sys_fork()?;
-
-    if child_pid == 0 {
-        sys_sleep(&TimeSpec {
-            tv_sec: 1,
-            tv_nsec: 0,
-        })?;
-
-        println!("[child] Sending a message...");
-
-        let msg_id = sys_ipc_send(parent_pid, &1337_u32.to_le_bytes(), IpcSendFlags::empty())?;
-
-        println!("[child] Sent message with ID = {}", msg_id);
-
-        sys_exit(0);
-    } else {
-        println!("[parent] Waiting for a message...");
-
-        let mut buffer = [0; 64];
-        let mut sender = 0;
-        let mut length = 0;
-
-        let msg_id = sys_ipc_recv(&mut buffer, &mut sender, &mut length, IpcRecvFlags::empty())?;
-
-        println!("[parent] Received a message with ID = {}", msg_id);
-        println!("[parent] Sender PID = {}", sender);
-        println!("[parent] Payload = {:?}", &buffer[0..length]);
-    }
 
     Ok(())
 }

--- a/userland/aero_shell/src/main.rs
+++ b/userland/aero_shell/src/main.rs
@@ -329,10 +329,10 @@ fn ipc_test() -> Result<(), AeroSyscallError> {
     let child_pid = sys_fork()?;
 
     if child_pid == 0 {
-        // sys_sleep(&TimeSpec {
-        //     tv_sec: 2,
-        //     tv_nsec: 0,
-        // })?;
+        sys_sleep(&TimeSpec {
+            tv_sec: 1,
+            tv_nsec: 0,
+        })?;
 
         println!("[child] Sending a message...");
 
@@ -342,11 +342,6 @@ fn ipc_test() -> Result<(), AeroSyscallError> {
 
         sys_exit(0);
     } else {
-        sys_sleep(&TimeSpec {
-            tv_sec: 1,
-            tv_nsec: 0,
-        })?;
-
         println!("[parent] Waiting for a message...");
 
         let mut buffer = [0; 64];

--- a/userland/aero_shell/src/main.rs
+++ b/userland/aero_shell/src/main.rs
@@ -138,6 +138,10 @@ fn repl(history: &mut Vec<String>) -> Result<(), AeroSyscallError> {
                 uwutest()?;
             }
 
+            "ipctest" => {
+                ipc_test()?;
+            }
+
             "pid" => {
                 println!("{}", sys_getpid()?);
             }
@@ -316,6 +320,45 @@ fn uwutest() -> Result<(), AeroSyscallError> {
 
     println!("uwutest: successfully bound to {:?}", SOCKET_PATH);
     list_directory(".")?;
+
+    Ok(())
+}
+
+fn ipc_test() -> Result<(), AeroSyscallError> {
+    let parent_pid = sys_getpid()?;
+    let child_pid = sys_fork()?;
+
+    if child_pid == 0 {
+        // sys_sleep(&TimeSpec {
+        //     tv_sec: 2,
+        //     tv_nsec: 0,
+        // })?;
+
+        println!("[child] Sending a message...");
+
+        let msg_id = sys_ipc_send(parent_pid, &1337_u32.to_le_bytes(), IpcSendFlags::empty())?;
+
+        println!("[child] Sent message with ID = {}", msg_id);
+
+        sys_exit(0);
+    } else {
+        sys_sleep(&TimeSpec {
+            tv_sec: 1,
+            tv_nsec: 0,
+        })?;
+
+        println!("[parent] Waiting for a message...");
+
+        let mut buffer = [0; 64];
+        let mut sender = 0;
+        let mut length = 0;
+
+        let msg_id = sys_ipc_recv(&mut buffer, &mut sender, &mut length, IpcRecvFlags::empty())?;
+
+        println!("[parent] Received a message with ID = {}", msg_id);
+        println!("[parent] Sender PID = {}", sender);
+        println!("[parent] Payload = {:?}", &buffer[0..length]);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This pull request aims to bring an easy way for processes to communicate with each other using dedicated system calls. There is still a lot of work to do, but it's something we can work upon.

The current system works in following way, there are 2 system calls available:
- `sys_ipc_send(target_pid, *buffer, flags);`
- `sys_ipc_recv(*buffer, *sender, *length, flags);`

The `sys_ipc_send` system call should always succeed, there aren't any planned error paths (for now at least). It will return the message ID assigned to the sent message.

The `sys_ipc_recv` system call will return the received message ID, the sender's PID will be written to the `*sender` argument and the message payload length will be written to the `*length` argument. Possible flags include `NO_WAIT` which makes the system call return with an error code `ENOMSG` if there aren't any messages in the message queue instead of waiting, and `TRUNCATE` which will truncate the payload if it's too big to fit in the buffer. By default the system call will return `E2BIG` and put the message back into the queue if it won't fit in provided buffer.