### PR TITLE
Aero IPC, by me

### DIFF
--- a/aero.py
+++ b/aero.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2021-2022 The Aero Project Developers.
 #

--- a/src/aero_kernel/src/syscall/ipc.rs
+++ b/src/aero_kernel/src/syscall/ipc.rs
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2021-2022 The Aero Project Developers.
+ *
+ * This file is part of The Aero Project.
+ *
+ * Aero is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Aero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Aero. If not, see <https://www.gnu.org/licenses/>.
+ */
 use crate::{
     userland::{
         scheduler::get_scheduler,

--- a/src/aero_kernel/src/syscall/ipc.rs
+++ b/src/aero_kernel/src/syscall/ipc.rs
@@ -109,18 +109,18 @@ pub fn recv(
                     .expect("empty message queues should always be deleted!");
                 if item.data.len() > messagemax {
                     m.queue.push_front(item);
-                    return Err(AeroSyscallError::E2BIG)
+                    return Err(AeroSyscallError::E2BIG);
                 }
                 if m.queue.len() == 0 {
                     msgqueue
                         .remove(&pid)
                         .expect("safety violation: modification of a value behind a mutex!");
                 }
-                return messagequeue_do_recieve(pidptr, messageptr, messagemax, item)
+                return messagequeue_do_recieve(pidptr, messageptr, messagemax, item);
             }
             None => {
                 // nope
-                return Err(AeroSyscallError::EAGAIN)
+                return Err(AeroSyscallError::EAGAIN);
             }
         }
     }

--- a/src/aero_kernel/src/syscall/ipc.rs
+++ b/src/aero_kernel/src/syscall/ipc.rs
@@ -1,0 +1,101 @@
+use crate::{
+    userland::{
+        scheduler::get_scheduler,
+    },
+    utils::{
+        sync::{BlockQueue, Mutex},
+        validate_slice_mut,
+    },
+};
+use aero_syscall::AeroSyscallError;
+use alloc::vec::Vec;
+use hashbrown::HashMap;
+use lazy_static::lazy_static;
+
+struct Message {
+    from: usize,
+    data: Vec<u8>,
+}
+
+lazy_static! {
+    static ref BLOCK_QUEUE: BlockQueue = BlockQueue::new();
+    static ref MESSAGES: Mutex<HashMap<usize, Option<Message>>> = Mutex::new(HashMap::new());
+}
+
+pub fn send(pid: usize, message: usize, messagesiz: usize) -> Result<usize, AeroSyscallError> {
+    let payload =
+        validate_slice_mut(message as *mut u8, messagesiz).ok_or(AeroSyscallError::EINVAL)?;
+
+    let mut bqueue = BLOCK_QUEUE
+        .block_on(&MESSAGES, |msg| {
+            let mp = msg.get(&pid);
+            match mp {
+                Some(None) => true,
+                _ => false,
+            }
+        })
+        .unwrap();
+    let bqueueitem = bqueue.get_mut(&pid).unwrap();
+    bqueueitem.replace(Message {
+        from: get_scheduler().current_task().pid().as_usize(),
+        data: payload.to_vec(),
+    });
+    BLOCK_QUEUE.notify_complete();
+    Ok(0)
+}
+pub fn recv(
+    pidptr: usize,
+    messageptr: usize,
+    messagemax: usize,
+    block: usize,
+) -> Result<usize, AeroSyscallError> {
+    let output =
+        validate_slice_mut(messageptr as *mut u8, messagemax).ok_or(AeroSyscallError::EINVAL)?;
+    let pid = get_scheduler().current_task().pid().as_usize();
+
+    if block == 0 {
+        // nonblocking read
+        let mut msgqueue = MESSAGES.lock();
+        match msgqueue.get(&pid) {
+            Some(m) => match m {
+                None => return Err(AeroSyscallError::EAGAIN),
+                Some(_) => {
+                    let m = msgqueue.remove(&pid).unwrap().unwrap();
+                    output.split_at_mut(m.data.len()).0.copy_from_slice(&m.data);
+                    BLOCK_QUEUE.notify_complete();
+                    unsafe {
+                        *(pidptr as *mut usize) = m.from;
+                    }
+                    return Ok(m.data.len());
+                }
+            },
+            None => {
+                // just set it up
+                msgqueue.insert(pid, None);
+                return Err(AeroSyscallError::EAGAIN);
+            }
+        }
+    }
+
+    let mut mqueue = MESSAGES.lock();
+    mqueue.insert(pid, None);
+    BLOCK_QUEUE.notify_complete();
+    drop(mqueue);
+
+    let mut bqueue = BLOCK_QUEUE
+        .block_on(&MESSAGES, |msg| {
+            let mp = msg.get(&pid);
+            match mp {
+                Some(Some(_)) => true,
+                _ => false,
+            }
+        })
+        .unwrap();
+    let m = bqueue.remove(&pid).unwrap().unwrap();
+    output.split_at_mut(m.data.len()).0.copy_from_slice(&m.data);
+    BLOCK_QUEUE.notify_complete();
+    unsafe {
+        *(pidptr as *mut usize) = m.from;
+    }
+    Ok(m.data.len())
+}

--- a/src/aero_kernel/src/syscall/ipc.rs
+++ b/src/aero_kernel/src/syscall/ipc.rs
@@ -17,7 +17,10 @@
  * along with Aero. If not, see <https://www.gnu.org/licenses/>.
  */
 use crate::{
-    userland::scheduler::get_scheduler,
+    userland::{
+        scheduler::{get_scheduler, SchedulerInterface},
+        task::TaskId,
+    },
     utils::{
         sync::{BlockQueue, Mutex},
         validate_slice_mut,
@@ -25,20 +28,27 @@ use crate::{
 };
 use aero_syscall::AeroSyscallError;
 use alloc::{collections::VecDeque, vec::Vec};
-use hashbrown::HashMap;
 use lazy_static::lazy_static;
 
 struct Message {
     from: usize,
     data: Vec<u8>,
 }
-struct MessageQueue {
-    pub queue: VecDeque<Message>,
+pub struct MessageQueue {
+    queue: Mutex<VecDeque<Message>>,
+    blockqueue: BlockQueue,
+}
+impl MessageQueue {
+    pub fn new() -> MessageQueue {
+        MessageQueue {
+            queue: Mutex::new(VecDeque::new()),
+            blockqueue: BlockQueue::new(),
+        }
+    }
 }
 
 lazy_static! {
     static ref BLOCK_QUEUE: BlockQueue = BlockQueue::new();
-    static ref MESSAGES: Mutex<HashMap<usize, MessageQueue>> = Mutex::new(HashMap::new());
 }
 
 fn messagequeue_do_recieve(
@@ -61,33 +71,18 @@ pub fn send(pid: usize, message: usize, messagesiz: usize) -> Result<usize, Aero
     let payload =
         validate_slice_mut(message as *mut u8, messagesiz).ok_or(AeroSyscallError::EINVAL)?;
 
-    let mut messagequeue = MESSAGES.lock();
-    match messagequeue.get_mut(&pid) {
-        Some(mq) => {
-            mq.queue.push_back(Message {
-                from: get_scheduler().current_task().pid().as_usize(),
-                data: payload.to_vec(),
-            });
-        }
-        None => {
-            messagequeue.insert(
-                pid,
-                MessageQueue {
-                    queue: [Message {
-                        from: get_scheduler().current_task().pid().as_usize(),
-                        data: payload.to_vec(),
-                    }]
-                    .into(),
-                },
-            );
-        }
-    }
-    // let bqueueitem = bqueue.get_mut(&pid).unwrap();
-    // bqueueitem.replace(Message {
-    //     from: get_scheduler().current_task().pid().as_usize(),
-    //     data: payload.to_vec(),
-    // });
-    BLOCK_QUEUE.notify_complete();
+    let target = get_scheduler()
+        .find_task(TaskId::new(pid))
+        .ok_or(AeroSyscallError::EINVAL)?;
+
+    let messagequeue = &target.message_queue;
+    let mut queue = messagequeue.queue.lock();
+
+    queue.push_back(Message {
+        from: get_scheduler().current_task().pid().as_usize(),
+        data: payload.to_vec(),
+    });
+    messagequeue.blockqueue.notify_complete();
     Ok(0)
 }
 pub fn recv(
@@ -96,62 +91,33 @@ pub fn recv(
     messagemax: usize,
     block: usize,
 ) -> Result<usize, AeroSyscallError> {
-    let pid = get_scheduler().current_task().pid().as_usize();
-
+    let current = get_scheduler().current_task();
     if block == 0 {
         // nonblocking read
-        let mut msgqueue = MESSAGES.lock();
-        match msgqueue.get_mut(&pid) {
-            Some(m) => {
-                let item = m
-                    .queue
-                    .pop_front()
-                    .expect("empty message queues should always be deleted!");
-                if item.data.len() > messagemax {
-                    m.queue.push_front(item);
-                    return Err(AeroSyscallError::E2BIG);
-                }
-                if m.queue.len() == 0 {
-                    msgqueue
-                        .remove(&pid)
-                        .expect("safety violation: modification of a value behind a mutex!");
-                }
-                return messagequeue_do_recieve(pidptr, messageptr, messagemax, item);
-            }
-            None => {
-                // nope
-                return Err(AeroSyscallError::EAGAIN);
-            }
+        let mut msgqueue = current.message_queue.queue.lock();
+        let item = msgqueue
+            .pop_front()
+            .expect("empty message queues should always be deleted!");
+        if item.data.len() > messagemax {
+            msgqueue.push_front(item);
+            return Err(AeroSyscallError::E2BIG);
         }
+        return messagequeue_do_recieve(pidptr, messageptr, messagemax, item);
     }
 
-    let mut queue_map = BLOCK_QUEUE
-        .block_on(&MESSAGES, |msg| {
-            let mp = msg.get_mut(&pid);
-            if let Some(mq) = mp {
-                mq.queue.front().is_some()
-            } else {
-                false
-            }
-        })
+    let mq = &current.message_queue;
+    let mut our_queue = mq
+        .blockqueue
+        .block_on(&mq.queue, |msg| msg.front().is_some())
         .unwrap();
 
-    let mq = queue_map
-        .get_mut(&pid)
-        .expect("someone else stole our messagequeue!");
-    let msg = mq
-        .queue
+    let msg = our_queue
         .pop_front()
         .expect("someone else stole our message!");
     if msg.data.len() > messagemax {
-        mq.queue.push_front(msg);
+        our_queue.push_front(msg);
         Err(AeroSyscallError::E2BIG)
     } else {
-        if mq.queue.len() == 0 {
-            queue_map
-                .remove(&pid)
-                .expect("safety violation: modification of a value behind a mutex!");
-        }
         messagequeue_do_recieve(pidptr, messageptr, messagemax, msg)
     }
 }

--- a/src/aero_kernel/src/syscall/mod.rs
+++ b/src/aero_kernel/src/syscall/mod.rs
@@ -65,6 +65,7 @@ pub mod fs;
 mod net;
 pub mod process;
 pub mod time;
+pub mod ipc;
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -73,6 +74,7 @@ pub use fs::*;
 pub use process::*;
 use raw_cpuid::CpuId;
 pub use time::*;
+pub use ipc::*;
 
 use crate::arch::signals;
 use crate::arch::{gdt::GdtEntryType, interrupts};
@@ -219,6 +221,9 @@ extern "C" fn __inner_syscall(sys: &mut SyscallFrame, stack: &mut RegistersFrame
 
         SYS_GETTIME => time::gettime(b, c),
         SYS_SLEEP => time::sleep(b),
+
+        SYS_IPC_SEND => ipc::send(b, c, d),
+        SYS_IPC_RECV => ipc::recv(b, c, d, e),
 
         _ => {
             log::error!("invalid syscall: {:#x}", a);

--- a/src/aero_kernel/src/userland/scheduler/mod.rs
+++ b/src/aero_kernel/src/userland/scheduler/mod.rs
@@ -112,9 +112,16 @@ impl Scheduler {
             .unwrap();
     }
 
+    /// Get the current task
     #[inline]
     pub fn current_task(&self) -> Arc<Task> {
         self.inner.current_task()
+    }
+
+    /// Lookup a task by ID
+    #[inline]
+    pub fn find_task(&self, task_id: TaskId) -> Option<Arc<Task>> {
+        self.tasks.0.lock().get(&task_id).map(|task| task.clone())
     }
 }
 

--- a/src/aero_syscall/src/consts.rs
+++ b/src/aero_syscall/src/consts.rs
@@ -63,6 +63,8 @@ pub const SYS_SIGPROCMASK: usize = 41;
 pub const SYS_DUP: usize = 42;
 pub const SYS_FCNTL: usize = 43;
 pub const SYS_DUP2: usize = 44;
+pub const SYS_IPC_SEND: usize = 45;
+pub const SYS_IPC_RECV: usize = 46;
 
 // fcntl constants:
 pub const F_GETFD: usize = 3;

--- a/src/aero_syscall/src/lib.rs
+++ b/src/aero_syscall/src/lib.rs
@@ -845,10 +845,7 @@ pub fn sys_ipc_send(pid: usize, message: &[u8]) -> Result<(), AeroSyscallError> 
         message.as_ptr() as usize,
         message.len(),
     );
-    match isize_as_syscall_result(value as _) {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e),
-    }
+    isize_as_syscall_result(value as _).map(|_| ())
 }
 
 pub fn sys_ipc_recv<'a>(

--- a/src/aero_syscall/src/lib.rs
+++ b/src/aero_syscall/src/lib.rs
@@ -866,8 +866,5 @@ pub fn sys_ipc_recv<'a>(
             false => 0,
         },
     );
-    match isize_as_syscall_result(value as _) {
-        Ok(siz) => Ok(&mut message[0..siz]),
-        Err(e) => Err(e),
-    }
+    isize_as_syscall_result(value as _).map(|size| &mut message[0..size])
 }

--- a/src/aero_syscall/src/lib.rs
+++ b/src/aero_syscall/src/lib.rs
@@ -858,10 +858,7 @@ pub fn sys_ipc_recv<'a>(
         pid as *mut usize as usize,
         message.as_ptr() as usize,
         message.len(),
-        match block {
-            true => 1,
-            false => 0,
-        },
+        block as usize,
     );
     isize_as_syscall_result(value as _).map(|size| &mut message[0..size])
 }

--- a/userland/Cargo.lock
+++ b/userland/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "aero_ipc"
+version = "0.1.0"
+dependencies = [
+ "aero_syscall",
+ "lazy_static",
+ "postcard",
+ "serde",
+ "spin 0.9.2",
+ "std",
+]
+
+[[package]]
 name = "aero_shell"
 version = "0.1.0"
 dependencies = [
@@ -18,10 +30,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+dependencies = [
+ "critical-section",
+ "riscv-target",
+]
+
+[[package]]
+name = "bare-metal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "bare-metal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+
+[[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cortex-m"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
+dependencies = [
+ "bare-metal 0.2.5",
+ "bitfield",
+ "embedded-hal",
+ "volatile-register",
+]
+
+[[package]]
+name = "critical-section"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e191a5a6f6edad9b679777ef6b6c0f2bdd4a333f2ecb8f61c3e28109a03d70"
+dependencies = [
+ "bare-metal 1.0.0",
+ "cfg-if",
+ "cortex-m",
+ "riscv",
+]
+
+[[package]]
+name = "embedded-hal"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+dependencies = [
+ "nb 0.1.3",
+ "void",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "serde",
+ "spin 0.9.2",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "init"
@@ -29,6 +155,15 @@ version = "0.1.0"
 dependencies = [
  "aero_syscall",
  "std",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -50,6 +185,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "nb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
+dependencies = [
+ "nb 1.0.0",
+]
+
+[[package]]
+name = "nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
+name = "postcard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
+dependencies = [
+ "heapless",
+ "postcard-cobs",
+ "serde",
+]
+
+[[package]]
+name = "postcard-cobs"
+version = "0.1.5-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +241,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "riscv"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
+dependencies = [
+ "bare-metal 1.0.0",
+ "bit_field",
+ "riscv-target",
+]
+
+[[package]]
+name = "riscv-target"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -92,12 +353,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "std"
 version = "0.1.0"
 dependencies = [
  "aero_syscall",
  "linked_list_allocator",
- "spin",
+ "spin 0.9.2",
 ]
 
 [[package]]
@@ -121,6 +388,7 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 name = "utest"
 version = "0.1.0"
 dependencies = [
+ "aero_ipc",
  "aero_syscall",
  "std",
  "utest-proc",
@@ -132,4 +400,25 @@ version = "0.1.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "vcell"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile-register"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
+dependencies = [
+ "vcell",
 ]

--- a/userland/Cargo.toml
+++ b/userland/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["aero_shell", "init", "utest"]
+members = ["aero_shell", "aero_ipc", "init", "utest"]

--- a/userland/aero_ipc/Cargo.toml
+++ b/userland/aero_ipc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aero_ipc"
+version = "0.1.0"
+authors = ["pitust <piotr@stelmaszek.com>"]
+edition = "2021"
+
+[dependencies]
+aero_syscall = { path = "../../src/aero_syscall" }
+postcard = { version = "0.7.3", features = ["alloc"] }
+std = { path = "../aero_std" }
+serde = { version = "1.0.136", default-features = false, features = ["alloc"] }
+spin = "0.9"
+
+[dependencies.lazy_static]
+version = "1.4.0"
+features = ["spin_no_std"]

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -54,7 +54,7 @@ impl MessageTransport for SendRecieveTransport {
         IDALLOC.fetch_xor(value << 13, Ordering::SeqCst);
         IDALLOC.fetch_xor(value >> 7, Ordering::SeqCst);
         IDALLOC.fetch_xor(value << 17, Ordering::SeqCst);
-        return IDALLOC.fetch_add(1, Ordering::SeqCst);
+        return IDALLOC.fetch_add(1, Ordering::SeqCst) >> 3;
     }
     fn free_id(_: usize) {}
     fn exchange(meta: usize, mid: usize, msg: &[u8]) -> Vec<u8> {
@@ -66,7 +66,7 @@ impl MessageTransport for SendRecieveTransport {
             let rx = service_with_response_finding();
             match rx {
                 // if we got a response,
-                Some((mut msg, srcpid)) => {
+                Some((srcpid, mut msg)) => {
                     // and the response has the correct message ID...
                     let mut deser = postcard::Deserializer::from_bytes(&msg);
                     let msgid = usize::deserialize(&mut deser)

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -24,12 +24,6 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use lazy_static::lazy_static;
 use serde::Deserialize;
 
-/// This is an ugly hack that exposes postcard and serde for the macro to use
-pub mod ipcmodules {
-    pub use postcard;
-    pub use serde;
-}
-
 /// A MessageHandler is a trait describing an IPC client
 pub trait MessageHandler: Send + Sync {
     fn handle(&mut self, src: usize, msg: &[u8]) -> Result<Option<Vec<u8>>, ()>;
@@ -81,6 +75,10 @@ impl MessageTransport for SendRecieveTransport {
         }
     }
 }
+
+pub extern crate postcard;
+pub extern crate serde;
+
 /// The IPC inteface macro
 ///
 /// You can create interfaces like this:
@@ -103,7 +101,7 @@ macro_rules! ipc {
     } } => {
         #[allow(non_snake_case)]
         pub mod $nm {
-            use $crate::ipcmodules::*;
+            use $crate::{postcard, serde};
             pub struct Client<T: $crate::MessageTransport> {
                 pub pid: usize,
                 pub phantom: ::core::marker::PhantomData<T>,

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -67,7 +67,7 @@ impl MessageTransport for SendRecieveTransport {
                         .expect("message ID not present in the message!");
                     if msgid == (mid << 1) | 1 {
                         // return the message contents!
-                        return msg.split_off(8);
+                        return msg.split_off(core::mem::size_of::<usize>());
                     }
                 }
                 None => {}

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -69,6 +69,7 @@ macro_rules! ipc {
             fn $fnnm:ident($($argname:ident : $argty:ty),*) $(-> $t:ty)?;
         )*
     } } => {
+        #[allow(non_snake_case)]
         pub mod $nm {
             use $crate::ipcmodules::*;
             pub struct Client<T: $crate::MessageTransport> {

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2021-2022 The Aero Project Developers.
+ *
+ * This file is part of The Aero Project.
+ *
+ * Aero is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Aero is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Aero. If not, see <https://www.gnu.org/licenses/>.
+ */
+#![feature(decl_macro)]
+
+use aero_syscall::{sys_ipc_recv, sys_ipc_send};
+use core::ops::DerefMut;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use lazy_static::lazy_static;
+use serde::Deserialize;
+
+pub mod ipcmodules {
+    pub use postcard;
+    pub use serde;
+}
+
+pub trait MessageHandler: Send + Sync {
+    fn handle(&mut self, src: usize, msg: &[u8]) -> Option<Vec<u8>>;
+}
+pub trait MessageTransport {
+    fn alloc_id() -> usize;
+    fn free_id(id: usize);
+    fn exchange(meta: usize, mid: usize, data: &[u8]) -> Vec<u8>;
+}
+pub struct SendRecieveTransport;
+static IDALLOC: AtomicUsize = AtomicUsize::new(0);
+impl MessageTransport for SendRecieveTransport {
+    fn alloc_id() -> usize {
+        return IDALLOC.fetch_add(1, Ordering::SeqCst);
+    }
+    fn free_id(_: usize) {}
+    fn exchange(meta: usize, mid: usize, msg: &[u8]) -> Vec<u8> {
+        sys_ipc_send(meta, msg).expect("exchange failed: request failed!");
+        loop {
+            let rx = service_with_response_finding();
+            match rx {
+                Some(mut msg) => {
+                    let mut deser = postcard::Deserializer::from_bytes(&msg);
+                    let msgid = usize::deserialize(&mut deser)
+                        .expect("message ID not present in the message!");
+                    if msgid == (mid << 1) | 1 {
+                        return msg.split_off(8);
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}
+#[macro_export]
+macro_rules! ipc {
+    { trait $nm:ident {
+        $(
+            fn $fnnm:ident($($argname:ident : $argty:ty),*) $(-> $t:ty)?;
+        )*
+    } } => {
+        pub mod $nm {
+            use $crate::ipcmodules::*;
+            pub struct Client<T: $crate::MessageTransport> {
+                pub pid: usize,
+                pub phantom: ::core::marker::PhantomData<T>,
+            }
+            impl<T: $crate::MessageTransport> Client<T> {
+                pub fn pid(&self) -> usize {
+                    self.pid
+                }
+                $(
+                    pub fn $fnnm(&self, $($argname: $argty),*) $(-> $t)? {
+                        let mid = T::alloc_id();
+                        let msg = postcard::to_allocvec(&(
+                            mid<<1, // messageid
+                            concat!(stringify!($nm), "::", stringify!($fnnm)) // method
+                            $(, $argname)* // args
+                        )).expect("serialize failed!");
+                        let resp = T::exchange(self.pid, mid, &msg);
+                        T::free_id(mid);
+                        postcard::from_bytes(&resp).expect("deserialize failed!")
+                    }
+                )*
+            }
+            pub fn open(pid: usize) -> Client<$crate::SendRecieveTransport> {
+                Client { pid, phantom: ::core::marker::PhantomData{} }
+            }
+            pub trait Server: Send + Sync {
+                $(
+                    fn $fnnm(&self, $($argname: $argty)*) $(-> $t)?;
+                )*
+            }
+            struct MessageHandlingProxy<T: 'static + Server>(T);
+            pub fn handler<T: 'static + Server>(server: T) -> Box<dyn $crate::MessageHandler> {
+                Box::new(MessageHandlingProxy(server))
+            }
+            impl<T: Server> $crate::MessageHandler for MessageHandlingProxy<T> {
+                fn handle(&mut self, _: usize, msg: &[u8]) -> Option<Vec<u8>> {
+                    use serde::Deserialize;
+
+                    let mut deser = postcard::Deserializer::from_bytes(msg);
+                    // TODO: cache this in the recieve part of the handler
+                    //? i don't think it would help *that* much though
+                    let msgid = usize::deserialize(&mut deser).expect("message ID not present in the message!");
+                    let method = String::deserialize(&mut deser).expect("message name not present in the message!");
+                    match method.as_str() {
+                        $(
+                            concat!(stringify!($nm), "::", stringify!($fnnm)) => {
+                                Some(postcard::to_allocvec(&(msgid, self.0.$fnnm(
+                                    $(
+                                        <$argty>::deserialize(&mut deser).expect("message deserialization failed!")
+                                    ),*
+                                ))).expect("response serialization failed!"))
+                            },
+                        )*
+                        _ => None
+                    }
+                }
+            }
+        }
+    }
+}
+
+lazy_static! {
+    static ref HANDLER_LIST: spin::Mutex<Vec<Box<dyn MessageHandler>>> = spin::Mutex::new(vec![]);
+    static ref RX_ARENA: spin::Mutex<Box<[u8; 0x4000]>> = spin::Mutex::new(Box::new([0; 0x4000]));
+}
+
+pub fn listen(iface: Box<dyn MessageHandler>) {
+    let mut list = HANDLER_LIST
+        .try_lock()
+        .expect("cannot listen() in a request handler!");
+
+    list.push(iface);
+}
+pub fn handle_request(src: usize, msg: &[u8]) -> Option<Vec<u8>> {
+    let mut list = HANDLER_LIST
+        .try_lock()
+        .expect("cannot nest request handlers!");
+    for i in list.deref_mut() {
+        match i.handle(src, msg) {
+            Some(data) => return Some(data),
+            None => {}
+        }
+    }
+    println!(
+        "\x1b[32;1mwarn\x1b[0m failed to dispatch message from {}!",
+        src
+    );
+    None
+}
+pub fn service_with_response_finding() -> Option<Vec<u8>> {
+    let mut src: usize = 0;
+    let mut arena = RX_ARENA.try_lock().expect("recieve arena is locked!");
+    let msg = sys_ipc_recv(&mut src, arena.as_mut(), true).expect("sys_ipc_recv failed!");
+    match handle_request(src, msg) {
+        Some(data) => {
+            sys_ipc_send(src, &data).expect("sys_ipc_send failed, reply dropped!");
+            None
+        }
+        _ => {
+            if
+            /* response */
+            (msg[0] & 1) == 1 {
+                Some(msg.to_vec())
+            } else {
+                None
+            }
+        }
+    }
+}
+pub fn service_request() {
+    let mut src: usize = 0;
+    let mut arena = RX_ARENA.try_lock().expect("recieve arena is locked!");
+    let msg = sys_ipc_recv(&mut src, arena.as_mut(), true).expect("sys_ipc_recv failed!");
+    match handle_request(src, msg) {
+        Some(data) => {
+            sys_ipc_send(src, &data).expect("sys_ipc_send failed, reply dropped!");
+        }
+        _ => {}
+    }
+}

--- a/userland/aero_ipc/src/lib.rs
+++ b/userland/aero_ipc/src/lib.rs
@@ -18,6 +18,9 @@
  */
 #![feature(decl_macro)]
 
+pub extern crate postcard;
+pub extern crate serde;
+
 use aero_syscall::{sys_ipc_recv, sys_ipc_send};
 use core::ops::DerefMut;
 use core::sync::atomic::{AtomicUsize, Ordering};
@@ -39,8 +42,10 @@ pub trait MessageTransport {
 
 /// A SendRecieveTransport transfers messages by using the IPC system calls.
 pub struct SendRecieveTransport;
+
 // trust me, this seed is fine
 static IDALLOC: AtomicUsize = AtomicUsize::new(0xde73_ce13_600f_e4e9);
+
 impl MessageTransport for SendRecieveTransport {
     fn alloc_id() -> usize {
         let value = IDALLOC.fetch_add(1, Ordering::SeqCst);
@@ -50,7 +55,9 @@ impl MessageTransport for SendRecieveTransport {
         IDALLOC.fetch_xor(value << 17, Ordering::SeqCst);
         return IDALLOC.fetch_add(1, Ordering::SeqCst) >> 3;
     }
+
     fn free_id(_: usize) {}
+
     fn exchange(meta: usize, mid: usize, msg: &[u8]) -> Vec<u8> {
         // send the data
         sys_ipc_send(meta, msg).expect("exchange failed: request failed!");
@@ -75,9 +82,6 @@ impl MessageTransport for SendRecieveTransport {
         }
     }
 }
-
-pub extern crate postcard;
-pub extern crate serde;
 
 /// The IPC inteface macro
 ///
@@ -124,33 +128,40 @@ macro_rules! ipc {
                     }
                 )*
             }
+
             pub fn open(pid: usize) -> Client<$crate::SendRecieveTransport> {
                 Client { pid, phantom: ::core::marker::PhantomData{} }
             }
+
             pub trait Server: Send + Sync {
                 $(
                     fn $fnnm(&self, $($argname: $argty)*) $(-> $t)?;
                 )*
             }
+
             struct MessageHandlingProxy<T: 'static + Server>(T);
+
             pub fn handler<T: 'static + Server>(server: T) -> Box<dyn $crate::MessageHandler> {
                 Box::new(MessageHandlingProxy(server))
             }
+
             impl<T: Server> $crate::MessageHandler for MessageHandlingProxy<T> {
                 fn handle(&mut self, _: usize, msg: &[u8]) -> Result<Option<Vec<u8>>, ()> {
                     use serde::Deserialize;
 
                     let mut deser = postcard::Deserializer::from_bytes(msg);
-                    // TODO: cache this in the recieve part of the handler
+                    // TODO(pitust): cache this in the recieve part of the handler
                     //? i don't think it would help *that* much though
                     let msgid: usize = usize::deserialize(&mut deser).or_else(|e| {
                         println!("\x1b[31;1merr\x1b[0m message id failed to deserialize!");
                         Err(())
                     })?;
+
                     let method = String::deserialize(&mut deser).or_else(|e| {
                         println!("\x1b[31;1merr\x1b[0m message name failed to deserialize!");
                         Err(())
                     })?;
+
                     match method.as_str() {
                         $(
                             concat!(stringify!($nm), "::", stringify!($fnnm)) => {
@@ -177,7 +188,7 @@ lazy_static! {
     static ref RX_ARENA: spin::Mutex<Box<[u8; 0x4000]>> = spin::Mutex::new(Box::new([0; 0x4000]));
 }
 
-/// Register a request listener
+/// Register a request listener.
 pub fn listen(iface: Box<dyn MessageHandler>) {
     let mut list = HANDLER_LIST
         .try_lock()
@@ -185,11 +196,13 @@ pub fn listen(iface: Box<dyn MessageHandler>) {
 
     list.push(iface);
 }
-/// Handle an IPC request from a specified process
+
+/// Handle an IPC request from a specified process.
 pub fn handle_request(src: usize, msg: &[u8]) -> Option<Vec<u8>> {
     let mut list = HANDLER_LIST
         .try_lock()
         .expect("cannot nest request handlers!");
+
     if (msg[0] & 1) == 1 {
         println!(
             "\x1b[32;1mwarn\x1b[0m recieved random response from {}!",
@@ -197,6 +210,7 @@ pub fn handle_request(src: usize, msg: &[u8]) -> Option<Vec<u8>> {
         );
         return None;
     }
+
     for i in list.deref_mut() {
         match i.handle(src, msg) {
             Ok(Some(data)) => return Some(data),
@@ -204,30 +218,41 @@ pub fn handle_request(src: usize, msg: &[u8]) -> Option<Vec<u8>> {
             Err(_) => return None,
         }
     }
+
     println!(
         "\x1b[32;1mwarn\x1b[0m failed to dispatch message from {}!",
         src
     );
+
     None
 }
+
 fn service_with_response_finding() -> Option<(usize, Vec<u8>)> {
     let mut src: usize = 0;
     let mut arena = RX_ARENA.try_lock().expect("recieve arena is locked!");
     let msg = sys_ipc_recv(&mut src, arena.as_mut(), true).expect("sys_ipc_recv failed!");
+
     // if it's a response
     if (msg[0] & 1) == 1 {
         return Some((src, msg.to_vec()));
     }
+
     if let Some(data) = handle_request(src, msg) {
         sys_ipc_send(src, &data).expect("sys_ipc_send failed, reply dropped!");
     }
+
     None
 }
+
 /// Service one request from the IPC queues
 pub fn service_request() {
     let mut src: usize = 0;
-    let mut arena = RX_ARENA.try_lock().expect("recieve arena is locked!");
+    let mut arena = RX_ARENA
+        .try_lock()
+        .expect("service_request: recieve arena is locked!");
+
     let msg = sys_ipc_recv(&mut src, arena.as_mut(), true).expect("sys_ipc_recv failed!");
+
     match handle_request(src, msg) {
         Some(data) => {
             sys_ipc_send(src, &data).expect("sys_ipc_send failed, reply dropped!");

--- a/userland/utest/Cargo.toml
+++ b/userland/utest/Cargo.toml
@@ -7,4 +7,5 @@ authors = ["Anhad Singh <andypythonappdeveloper@gmail.com>"]
 [dependencies]
 std = { path = "../aero_std" }
 aero_syscall = { path = "../../src/aero_syscall" }
+aero_ipc = { path = "../aero_ipc" }
 utest-proc = { path = "../utest-proc" }

--- a/userland/utest/src/main.rs
+++ b/userland/utest/src/main.rs
@@ -34,6 +34,7 @@ pub struct Test<'a> {
 static TEST_FUNCTIONS: &[&'static Test<'static>] = &[
     // TODO: Why does clone process fail?
     // &clone_process,
+    &rpc_test,
     &forked_pipe,
     &signal_handler,
     &dup_fds,
@@ -41,7 +42,6 @@ static TEST_FUNCTIONS: &[&'static Test<'static>] = &[
     &fcntl_get_set_fdflags,
     // mmap tests:
     &mmap::zero_sized_mapping,
-    &rpc_test
 ];
 
 fn main() {
@@ -174,6 +174,8 @@ fn signal_handler() -> Result<(), AeroSyscallError> {
         // Close the pipe
         sys_close(pipe[0])?;
         sys_close(pipe[1])?;
+
+        sys_exit(0)
     } else {
         let mut status = 0;
         sys_waitpid(child, &mut status, 0)?;
@@ -289,7 +291,6 @@ fn clone_process() -> Result<(), AeroSyscallError> {
     Ok(())
 }
 
-
 aero_ipc::ipc! {
     trait Hello {
         fn hello(favorite_number: i32) -> ();
@@ -307,6 +308,6 @@ fn rpc_test() -> Result<(), AeroSyscallError> {
     aero_ipc::listen(Hello::handler(HelloServer {}));
     let c = Hello::open(sys_getpid().unwrap());
     c.hello(3);
-    
+
     Ok(())
 }

--- a/userland/utest/src/main.rs
+++ b/userland/utest/src/main.rs
@@ -298,11 +298,13 @@ aero_ipc::ipc! {
 }
 
 struct HelloServer;
+
 impl Hello::Server for HelloServer {
     fn hello(&self, favnum: i32) {
         println!("hey: {}", favnum);
     }
 }
+
 #[utest_proc::test]
 fn rpc_test() -> Result<(), AeroSyscallError> {
     aero_ipc::listen(Hello::handler(HelloServer {}));


### PR DESCRIPTION
This PR supersedes #47, creating a fast IPC mechanism for aero. It is mostly modeled after #47's design, as well as the xtrix design.

It introduces two new system calls, one sends and one receives a message. The identity of the source process is public and passed to the caller.

In addition to that, it introduces a new library, `aero_ipc`, which allows for high-level remote procedure calls over the low-level interface.

A simple interface looks like this:
```rust
aero_ipc::ipc! {
    trait Hello {
        fn hello(favorite_number: i32) -> ();
    }
}

struct HelloServer;
impl Hello::Server for HelloServer {
    fn hello(&self, favnum: i32) {
        println!("hey: {}", favnum);
    }
}
fn main() {
    aero_ipc::listen(Hello::handler(HelloServer {}));
    let c = Hello::open(sys_getpid().unwrap());
    c.hello(3);
    
    Ok(())
}
```
(as per the RPC test)

Closes #47 