### PR TITLE
Add and enable several x86_64 security features

### DIFF
--- a/aero.py
+++ b/aero.py
@@ -470,11 +470,11 @@ def run_in_emulator(args, iso_path):
         print("Running with KVM acceleration enabled")
 
         if platform.system() == 'Darwin':
-            qemu_args += ['-accel', 'hvf', '-cpu', 'qemu64,+la57,+smap' if args.la57 else 'qemu64,+smap']
+            qemu_args += ['-accel', 'hvf', '-cpu', 'qemu64,+la57,+smap,+smep,+umip' if args.la57 else 'qemu64,+smap,+smep,+umip']
         else:
-            qemu_args += ['-enable-kvm', '-cpu', 'host,+la57,+smap' if args.la57 else 'host,+smap']
+            qemu_args += ['-enable-kvm', '-cpu', 'host,+la57,+smap,+smep,+umip' if args.la57 else 'host,+smap,+smep,+umip']
     else:
-        qemu_args += ["-cpu", "qemu64,+la57,+smap" if args.la57 else "qemu64,+smap"]
+        qemu_args += ["-cpu", "qemu64,+la57,+smap,+smep,+umip" if args.la57 else "qemu64,+smap,+smep,+umip"]
 
     run_command(['qemu-system-x86_64', *qemu_args])
 

--- a/aero.py
+++ b/aero.py
@@ -470,11 +470,11 @@ def run_in_emulator(args, iso_path):
         print("Running with KVM acceleration enabled")
 
         if platform.system() == 'Darwin':
-            qemu_args += ['-accel', 'hvf', '-cpu', 'qemu64,+la57' if args.la57 else 'qemu64']
+            qemu_args += ['-accel', 'hvf', '-cpu', 'qemu64,+la57,+smap' if args.la57 else 'qemu64,+smap']
         else:
-            qemu_args += ['-enable-kvm', '-cpu', 'host,+la57' if args.la57 else 'host']
+            qemu_args += ['-enable-kvm', '-cpu', 'host,+la57,+smap' if args.la57 else 'host,+smap']
     else:
-        qemu_args += ["-cpu", "qemu64,+la57" if args.la57 else "qemu64"]
+        qemu_args += ["-cpu", "qemu64,+la57,+smap" if args.la57 else "qemu64,+smap"]
 
     run_command(['qemu-system-x86_64', *qemu_args])
 

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -236,9 +236,9 @@ tools:
         # -g blows up the binary size.
         - 'CFLAGS=-pipe'
     compile:
-      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', '-j@PARALLELISM@', 'all-binutils', 'all-gas', 'all-ld']
     install:
-      - args: ['make', 'install']
+      - args: ['make', 'install-binutils', 'install-gas', 'install-ld']
 
   - name: host-gcc
     from_source: gcc

--- a/src/aero_kernel/src/arch/x86_64/mod.rs
+++ b/src/aero_kernel/src/arch/x86_64/mod.rs
@@ -251,6 +251,7 @@ pub fn init_cpu() {
 
             cr0.remove(controlregs::Cr0Flags::EMULATE_COPROCESSOR);
             cr0.insert(controlregs::Cr0Flags::MONITOR_COPROCESSOR);
+            cr0.insert(controlregs::Cr0Flags::WRITE_PROTECT);
 
             controlregs::write_cr0(cr0);
         }

--- a/src/aero_kernel/src/arch/x86_64/mod.rs
+++ b/src/aero_kernel/src/arch/x86_64/mod.rs
@@ -262,6 +262,11 @@ pub fn init_cpu() {
                 .get_extended_feature_info()
                 .map_or(false, |i| i.has_smap());
 
+            // Check if SMEP is supported.
+            let has_smep = CpuId::new()
+                .get_extended_feature_info()
+                .map_or(false, |i| i.has_smep());
+
             let mut cr4 = controlregs::read_cr4();
 
             if has_smap {
@@ -269,6 +274,13 @@ pub fn init_cpu() {
                 cr4.insert(controlregs::Cr4Flags::SUPERVISOR_MODE_ACCESS_PREVENTION);
             } else {
                 log::info!("SMAP is not supported.");
+            }
+
+            if has_smep {
+                log::info!("SMEP is supported, enabling SMEP.");
+                cr4.insert(controlregs::Cr4Flags::SUPERVISOR_MODE_EXECUTION_PROTECTION);
+            } else {
+                log::info!("SMEP is not supported.");
             }
 
             cr4.insert(controlregs::Cr4Flags::OSFXSR);

--- a/src/aero_kernel/src/arch/x86_64/mod.rs
+++ b/src/aero_kernel/src/arch/x86_64/mod.rs
@@ -146,15 +146,15 @@ extern "C" fn x86_64_aero_main(boot_info: &'static StivaleStruct) -> ! {
             .unwrap()
     });
 
-    // Initialize the CPU specific features.
-    init_cpu();
-
     // We initialize the COM ports before doing anything else.
     //
     // This will help printing panics and logs before or when the debug renderer
     // is initialized and if serial output is avaliable.
     drivers::uart_16550::init();
     logger::init();
+
+    // Initialize the CPU specific features.
+    init_cpu();
 
     // Parse the kernel command line.
     let command_line: &'static _ = boot_info.command_line().map_or("", |cmd| unsafe {

--- a/src/aero_kernel/src/arch/x86_64/mod.rs
+++ b/src/aero_kernel/src/arch/x86_64/mod.rs
@@ -267,6 +267,11 @@ pub fn init_cpu() {
                 .get_extended_feature_info()
                 .map_or(false, |i| i.has_smep());
 
+            // Check if UMIP is supported.
+            let has_umip = CpuId::new()
+                .get_extended_feature_info()
+                .map_or(false, |i| i.has_umip());
+
             let mut cr4 = controlregs::read_cr4();
 
             if has_smap {
@@ -281,6 +286,13 @@ pub fn init_cpu() {
                 cr4.insert(controlregs::Cr4Flags::SUPERVISOR_MODE_EXECUTION_PROTECTION);
             } else {
                 log::info!("SMEP is not supported.");
+            }
+
+            if has_umip {
+                log::info!("UMIP is supported, enabling UMIP.");
+                cr4.insert(controlregs::Cr4Flags::USER_MODE_INSTRUCTION_PREVENTION);
+            } else {
+                log::info!("UMIP is not supported.");
             }
 
             cr4.insert(controlregs::Cr4Flags::OSFXSR);

--- a/src/aero_kernel/src/arch/x86_64/mod.rs
+++ b/src/aero_kernel/src/arch/x86_64/mod.rs
@@ -256,7 +256,19 @@ pub fn init_cpu() {
         }
 
         {
+            // Check if SMAP is supported.
+            let has_smap = CpuId::new()
+                .get_extended_feature_info()
+                .map_or(false, |i| i.has_smap());
+
             let mut cr4 = controlregs::read_cr4();
+
+            if has_smap {
+                log::info!("SMAP is supported, enabling SMAP.");
+                cr4.insert(controlregs::Cr4Flags::SUPERVISOR_MODE_ACCESS_PREVENTION);
+            } else {
+                log::info!("SMAP is not supported.");
+            }
 
             cr4.insert(controlregs::Cr4Flags::OSFXSR);
             cr4.insert(controlregs::Cr4Flags::OSXMMEXCPT_ENABLE);

--- a/src/aero_kernel/src/arch/x86_64/signals.rs
+++ b/src/aero_kernel/src/arch/x86_64/signals.rs
@@ -20,6 +20,7 @@
 use crate::userland;
 use crate::userland::scheduler;
 use crate::utils::StackHelper;
+use crate::arch::controlregs;
 
 use super::interrupts::InterruptStack;
 
@@ -107,11 +108,11 @@ pub fn sigreturn(stack: &mut InterruptStack) -> usize {
 
     let current_task = scheduler::get_scheduler().current_task();
 
-    current_task.signals().set_mask(
+    controlregs::with_userspace_access(||current_task.signals().set_mask(
         aero_syscall::signal::SigProcMask::Set,
         signal_frame.sigmask,
         None,
-    );
+    ));
 
     writer.get_by(REDZONE_SIZE);
 

--- a/src/aero_kernel/src/drivers/tty.rs
+++ b/src/aero_kernel/src/drivers/tty.rs
@@ -265,13 +265,13 @@ impl INodeInterface for Tty {
 
                 let (rows, cols) = crate::rendy::get_rows_cols();
 
-                winsize.ws_row = rows as u16;
-                winsize.ws_col = cols as u16;
+                controlregs::with_userspace_access(||winsize.ws_row = rows as u16);
+                controlregs::with_userspace_access(||winsize.ws_col = cols as u16);
 
                 let (xpixel, ypixel) = crate::rendy::get_resolution();
 
-                winsize.ws_xpixel = xpixel as u16;
-                winsize.ws_ypixel = ypixel as u16;
+                controlregs::with_userspace_access(||winsize.ws_xpixel = xpixel as u16);
+                controlregs::with_userspace_access(||winsize.ws_ypixel = ypixel as u16);
 
                 Ok(0x00)
             }
@@ -283,7 +283,7 @@ impl INodeInterface for Tty {
                 let lock = TERMIOS.lock_irq();
                 let this = &*lock;
 
-                *termios = this.clone();
+                controlregs::with_userspace_access(||*termios = this.clone());
                 Ok(0x00)
             }
 
@@ -300,7 +300,7 @@ impl INodeInterface for Tty {
                 let mut lock = TERMIOS.lock_irq();
                 let this = &mut *lock;
 
-                *this = termios.clone();
+                controlregs::with_userspace_access(||*this = termios.clone());
                 Ok(0x00)
             }
 

--- a/src/aero_kernel/src/drivers/tty.rs
+++ b/src/aero_kernel/src/drivers/tty.rs
@@ -28,6 +28,7 @@ use crate::fs::inode;
 use crate::fs::inode::INodeInterface;
 use crate::mem::paging::VirtAddr;
 use crate::utils::sync::{BlockQueue, Mutex};
+use crate::arch::controlregs;
 
 use super::keyboard::KeyCode;
 use super::keyboard::KeyboardListener;
@@ -234,11 +235,11 @@ impl INodeInterface for Tty {
 
         if buffer.len() > stdin.front_buffer.len() {
             for (i, c) in stdin.front_buffer.drain(..).enumerate() {
-                buffer[i] = c;
+                controlregs::with_userspace_access(||buffer[i] = c);
             }
         } else {
             for (i, c) in stdin.front_buffer.drain(..buffer.len()).enumerate() {
-                buffer[i] = c;
+                controlregs::with_userspace_access(||buffer[i] = c);
             }
         }
 

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -289,7 +289,7 @@ pub fn unlink(
     path_size: usize,
     flags: usize,
 ) -> Result<usize, AeroSyscallError> {
-    let path_str = validate_str(path as *mut u8, path_size).ok_or(AeroSyscallError::EINVAL)?;
+    let path_str = controlregs::with_userspace_access(||validate_str(path as *mut u8, path_size).ok_or(AeroSyscallError::EINVAL))?;
     let path = Path::new(path_str);
 
     // TODO: Make use of the open flags.

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -151,7 +151,7 @@ pub fn chdir(path: usize, size: usize) -> Result<usize, AeroSyscallError> {
 }
 
 pub fn mkdirat(dfd: usize, path: usize, size: usize) -> Result<usize, AeroSyscallError> {
-    let path_str = validate_str(path as *mut u8, size).ok_or(AeroSyscallError::EINVAL)?;
+    let path_str = controlregs::with_userspace_access(||validate_str(path as *mut u8, size).ok_or(AeroSyscallError::EINVAL))?;
     let path = Path::new(path_str);
 
     // NOTE: If the pathname given in pathname is relative, then it is interpreted

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -20,6 +20,8 @@
 use aero_syscall::prelude::FdFlags;
 use aero_syscall::{AeroSyscallError, OpenFlags};
 
+use crate::arch::controlregs;
+
 use crate::fs::inode::DirEntry;
 use crate::fs::pipe::Pipe;
 use crate::fs::{self, lookup_path, LookupMode};
@@ -39,8 +41,8 @@ pub fn write(fd: usize, buffer: usize, size: usize) -> Result<usize, AeroSyscall
         .flags
         .intersects(OpenFlags::O_WRONLY | OpenFlags::O_RDWR)
     {
-        let buffer = validate_slice(buffer as *const u8, size).ok_or(AeroSyscallError::EINVAL)?;
-        Ok(handle.write(buffer)?)
+        let buffer = controlregs::with_userspace_access(||validate_slice(buffer as *const u8, size).ok_or(AeroSyscallError::EINVAL))?;
+        Ok(controlregs::with_userspace_access(||handle.write(buffer))?)
     } else {
         Err(AeroSyscallError::EACCES)
     }
@@ -57,8 +59,8 @@ pub fn read(fd: usize, buffer: usize, size: usize) -> Result<usize, AeroSyscallE
         .flags
         .intersects(OpenFlags::O_RDONLY | OpenFlags::O_RDWR)
     {
-        let buffer = validate_slice_mut(buffer as *mut u8, size).ok_or(AeroSyscallError::EINVAL)?;
-        Ok(handle.read(buffer)?)
+        let buffer = controlregs::with_userspace_access(||validate_slice_mut(buffer as *mut u8, size).ok_or(AeroSyscallError::EINVAL))?;
+        Ok(controlregs::with_userspace_access(||handle.read(buffer))?)
     } else {
         Err(AeroSyscallError::EACCES)
     }
@@ -71,7 +73,7 @@ pub fn open(_fd: usize, path: usize, len: usize, mode: usize) -> Result<usize, A
         flags.insert(OpenFlags::O_RDONLY);
     }
 
-    let path = validate_str(path as *const u8, len).ok_or(AeroSyscallError::EINVAL)?;
+    let path = controlregs::with_userspace_access(||validate_str(path as *const u8, len).ok_or(AeroSyscallError::EINVAL))?;
     let path = Path::new(path);
 
     let mut lookup_mode = LookupMode::None;
@@ -80,7 +82,7 @@ pub fn open(_fd: usize, path: usize, len: usize, mode: usize) -> Result<usize, A
         lookup_mode = LookupMode::Create;
     }
 
-    let inode = fs::lookup_path_with_mode(path, lookup_mode)?;
+    let inode = controlregs::with_userspace_access(||fs::lookup_path_with_mode(path, lookup_mode))?;
 
     if flags.contains(OpenFlags::O_DIRECTORY) && !inode.inode().metadata()?.is_directory() {
         return Err(AeroSyscallError::ENOTDIR);
@@ -118,7 +120,7 @@ pub fn getdents(fd: usize, buffer: usize, size: usize) -> Result<usize, AeroSysc
         .ok_or(AeroSyscallError::EBADFD)?;
 
     let buffer = validate_slice_mut(buffer as *mut u8, size).ok_or(AeroSyscallError::EINVAL)?;
-    Ok(handle.get_dents(buffer)?)
+    Ok(controlregs::with_userspace_access(||handle.get_dents(buffer))?)
 }
 
 pub fn close(fd: usize) -> Result<usize, AeroSyscallError> {
@@ -224,7 +226,7 @@ pub fn getcwd(buffer: usize, size: usize) -> Result<usize, AeroSyscallError> {
     let buffer = validate_slice_mut(buffer as *mut u8, size).ok_or(AeroSyscallError::EINVAL)?;
     let cwd = scheduler::get_scheduler().current_task().get_cwd();
 
-    buffer[..cwd.len()].copy_from_slice(cwd.as_bytes());
+    controlregs::with_userspace_access(||buffer[..cwd.len()].copy_from_slice(cwd.as_bytes()));
     Ok(cwd.len())
 }
 

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -138,7 +138,7 @@ pub fn close(fd: usize) -> Result<usize, AeroSyscallError> {
 }
 
 pub fn chdir(path: usize, size: usize) -> Result<usize, AeroSyscallError> {
-    let buffer = validate_str(path as *mut u8, size).ok_or(AeroSyscallError::EINVAL)?;
+    let buffer = controlregs::with_userspace_access(||validate_str(path as *mut u8, size).ok_or(AeroSyscallError::EINVAL))?;
     let inode = fs::lookup_path(Path::new(buffer))?;
 
     if !inode.inode().metadata()?.is_directory() {

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -199,7 +199,7 @@ pub fn mkdir(path: usize, size: usize) -> Result<usize, AeroSyscallError> {
 }
 
 pub fn rmdir(path: usize, size: usize) -> Result<usize, AeroSyscallError> {
-    let path_str = validate_str(path as *mut u8, size).ok_or(AeroSyscallError::EINVAL)?;
+    let path_str = controlregs::with_userspace_access(||validate_str(path as *mut u8, size).ok_or(AeroSyscallError::EINVAL))?;
     let path = Path::new(path_str);
 
     let (_, child) = path.parent_and_basename();

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -277,8 +277,8 @@ pub fn pipe(fds: usize, flags: usize) -> Result<usize, AeroSyscallError> {
         Ok(fd2) => fd2,
     };
 
-    fds[0] = fd1;
-    fds[1] = fd2;
+    controlregs::with_userspace_access(||fds[0] = fd1);
+    controlregs::with_userspace_access(||fds[1] = fd2);
 
     Ok(0x00)
 }
@@ -321,7 +321,7 @@ pub fn access(
     _mode: usize,
     _flags: usize,
 ) -> Result<usize, AeroSyscallError> {
-    let path_str = validate_str(path as *mut u8, path_size).ok_or(AeroSyscallError::EINVAL)?;
+    let path_str = controlregs::with_userspace_access(||validate_str(path as *mut u8, path_size).ok_or(AeroSyscallError::EINVAL))?;
     let path = Path::new(path_str);
 
     if fd as isize == aero_syscall::AT_FDCWD {

--- a/src/aero_kernel/src/syscall/process.rs
+++ b/src/aero_kernel/src/syscall/process.rs
@@ -137,7 +137,7 @@ pub fn exec(
 }
 
 pub fn log(msg_start: usize, msg_size: usize) -> Result<usize, AeroSyscallError> {
-    let message = validate_str(msg_start as *const u8, msg_size).ok_or(AeroSyscallError::EINVAL)?;
+    let message = controlregs::with_userspace_access(||validate_str(msg_start as *const u8, msg_size).ok_or(AeroSyscallError::EINVAL))?;
     log::debug!("{}", message);
 
     Ok(0x00)

--- a/src/aero_kernel/src/syscall/process.rs
+++ b/src/aero_kernel/src/syscall/process.rs
@@ -22,6 +22,8 @@ use aero_syscall::{AeroSyscallError, MMapFlags, MMapProt};
 use alloc::string::String;
 use spin::{Mutex, Once};
 
+use crate::arch::controlregs;
+
 use crate::fs;
 use crate::fs::Path;
 
@@ -104,10 +106,10 @@ pub fn exec(
     envs: usize,
     envc: usize,
 ) -> Result<usize, AeroSyscallError> {
-    let path = validate_str(path as *const u8, path_size).ok_or(AeroSyscallError::EINVAL)?;
+    let path = controlregs::with_userspace_access(||validate_str(path as *const u8, path_size).ok_or(AeroSyscallError::EINVAL))?;
     let path = Path::new(path);
 
-    let executable = fs::lookup_path(path)?;
+    let executable = controlregs::with_userspace_access(||fs::lookup_path(path))?;
 
     if executable.inode().metadata()?.is_directory() {
         return Err(AeroSyscallError::EISDIR);
@@ -145,7 +147,7 @@ pub fn waitpid(pid: usize, status: usize, _flags: usize) -> Result<usize, AeroSy
     let current_task = scheduler::get_scheduler().current_task();
     let status = unsafe { &mut *(status as *mut u32) };
 
-    Ok(current_task.waitpid(pid, status)?)
+    Ok(controlregs::with_userspace_access(||current_task.waitpid(pid, status))?)
 }
 
 pub fn mmap(
@@ -215,7 +217,7 @@ pub fn gethostname(ptr: usize, length: usize) -> Result<usize, AeroSyscallError>
     if bytes.len() > slice.len() {
         Err(AeroSyscallError::ENAMETOOLONG)
     } else {
-        slice[0..bytes.len()].copy_from_slice(bytes);
+        controlregs::with_userspace_access(||slice[0..bytes.len()].copy_from_slice(bytes));
 
         Ok(bytes.len())
     }
@@ -225,7 +227,7 @@ pub fn info(struc: usize) -> Result<usize, AeroSyscallError> {
     let struc = unsafe { &mut *(struc as *mut aero_syscall::SysInfo) };
 
     // TODO: Fill in the rest of the struct.
-    struc.uptime = crate::time::get_uptime_ticks() as i64;
+    controlregs::with_userspace_access(||struc.uptime = crate::time::get_uptime_ticks() as i64);
 
     Ok(0x00)
 }
@@ -235,7 +237,7 @@ pub fn sethostname(ptr: usize, length: usize) -> Result<usize, AeroSyscallError>
 
     match core::str::from_utf8(slice) {
         Ok(new_hostname) => {
-            *hostname().lock() = String::from(new_hostname);
+            controlregs::with_userspace_access(||*hostname().lock() = String::from(new_hostname));
             Ok(0)
         }
         Err(_) => Err(AeroSyscallError::EINVAL),
@@ -259,7 +261,7 @@ pub fn sigaction(
     };
 
     let entry = if let Some(new) = new {
-        Some(SignalEntry::from_sigaction(*new, sigreturn)?)
+        Some(controlregs::with_userspace_access(||SignalEntry::from_sigaction(*new, sigreturn))?)
     } else {
         None
     };
@@ -278,7 +280,7 @@ pub fn sigaction(
     let task = scheduler.current_task();
     let signals = task.signals();
 
-    signals.set_signal(sig, entry, old);
+    controlregs::with_userspace_access(||signals.set_signal(sig, entry, old));
 
     Ok(0)
 }

--- a/src/aero_kernel/src/syscall/process.rs
+++ b/src/aero_kernel/src/syscall/process.rs
@@ -59,7 +59,7 @@ pub fn uname(buffer: usize) -> Result<usize, AeroSyscallError> {
         let init_bytes = init.as_bytes();
         let len = init.len();
 
-        fixed[..len].copy_from_slice(init_bytes)
+        controlregs::with_userspace_access(||fixed[..len].copy_from_slice(init_bytes))
     }
 
     // TODO: Safety checks!

--- a/src/aero_kernel/src/unwind.rs
+++ b/src/aero_kernel/src/unwind.rs
@@ -32,6 +32,7 @@ use crate::logger;
 use crate::rendy;
 
 use crate::arch::interrupts;
+use crate::arch::controlregs;
 
 static PANIC_HOOK_READY: AtomicBool = AtomicBool::new(false);
 
@@ -186,7 +187,7 @@ extern "C" fn rust_begin_unwind(info: &PanicInfo) -> ! {
     // Add a new line to make the stack trace more readable.
     log::error!("");
 
-    unwind_stack_trace();
+    controlregs::with_userspace_access(||unwind_stack_trace());
 
     #[cfg(feature = "ci")]
     emu::exit_qemu(emu::ExitStatus::Success);

--- a/src/aero_kernel/src/userland/signals.rs
+++ b/src/aero_kernel/src/userland/signals.rs
@@ -29,6 +29,7 @@ use bit_field::BitField;
 use aero_syscall::AeroSyscallError;
 
 use super::scheduler;
+use crate::arch::controlregs;
 use crate::fs::FileSystemError;
 use crate::utils::sync::{Mutex, MutexGuard};
 
@@ -391,7 +392,7 @@ impl Signals {
             *old = self.blocked_mask.load(Ordering::SeqCst);
         }
 
-        let set = set & !IMMUTABLE_MASK;
+        let set = controlregs::with_userspace_access(||set & !IMMUTABLE_MASK);
 
         match how {
             SigProcMask::Block => {

--- a/src/aero_kernel/src/userland/vm.rs
+++ b/src/aero_kernel/src/userland/vm.rs
@@ -27,6 +27,7 @@ use xmas_elf::header::*;
 use xmas_elf::program::*;
 use xmas_elf::*;
 
+use crate::arch::controlregs;
 use crate::arch::task::userland_last_address;
 use crate::fs;
 use crate::fs::cache::DirCacheItem;
@@ -385,7 +386,7 @@ impl Mapping {
         let new_slice = new_frame.as_slice_mut::<u8>();
 
         // Copy the contents from the old frame to the newly allocated frame.
-        new_slice.copy_from_slice(old_slice);
+        controlregs::with_userspace_access(||new_slice.copy_from_slice(old_slice));
 
         // Re-map the page to the newly allocated frame and with the provided
         // protection flags.

--- a/userland/apps/aero_shell/src/main.rs
+++ b/userland/apps/aero_shell/src/main.rs
@@ -144,7 +144,7 @@ fn repl(history: &mut Vec<String>) -> Result<(), AeroSyscallError> {
             }
 
             "uptime" => {
-                print!("{}", get_uptime()?);
+                println!("{}", get_uptime()?);
             }
 
             "sleep" => {


### PR DESCRIPTION
This PR aims to implement support for SMAP, SMEP and UMIP, and is provided as a draft so that my non existent rust skills can be reviewed already. It also enables bit 16 in CR0 for more write protection. As this is a draft, not everything is implemented or working yet, but on SMAP capable systems, aero_shell runs with SMAP and `ls` is working.