### PR TITLE
Add support for system calls with the `sysenter` instruction

### DIFF
--- a/src/aero_kernel/src/arch/x86_64/gdt.rs
+++ b/src/aero_kernel/src/arch/x86_64/gdt.rs
@@ -126,16 +126,7 @@ static GDT: [GdtEntry; GDT_ENTRY_COUNT] = [
             | GdtAccessFlags::PRIVILEGE,
         GdtEntryFlags::LONG_MODE,
     ),
-    // GDT dummy user code descriptor. Required for SYSEXIT.
-    GdtEntry::new(
-        GdtAccessFlags::PRESENT
-            | GdtAccessFlags::RING_0
-            | GdtAccessFlags::SYSTEM
-            | GdtAccessFlags::EXECUTABLE
-            | GdtAccessFlags::PRIVILEGE,
-        GdtEntryFlags::PROTECTED_MODE,
-    ),
-    // GDT user data descriptor.
+    // GDT user data descriptor. (used by SYSCALL)
     GdtEntry::new(
         GdtAccessFlags::PRESENT
             | GdtAccessFlags::RING_3
@@ -149,6 +140,14 @@ static GDT: [GdtEntry; GDT_ENTRY_COUNT] = [
             | GdtAccessFlags::RING_3
             | GdtAccessFlags::SYSTEM
             | GdtAccessFlags::EXECUTABLE
+            | GdtAccessFlags::PRIVILEGE,
+        GdtEntryFlags::LONG_MODE,
+    ),
+    // GDT user data descriptor. (used by SYSENTER)
+    GdtEntry::new(
+        GdtAccessFlags::PRESENT
+            | GdtAccessFlags::RING_3
+            | GdtAccessFlags::SYSTEM
             | GdtAccessFlags::PRIVILEGE,
         GdtEntryFlags::LONG_MODE,
     ),
@@ -189,7 +188,6 @@ impl GdtEntryType {
     pub const KERNEL_CODE: u16 = 1;
     pub const KERNEL_DATA: u16 = 2;
     pub const KERNEL_TLS: u16 = 3;
-    pub const USER_CODE32_UNUSED: u16 = 4;
     pub const TSS: u16 = 8;
     pub const TSS_HI: u16 = 9;
 }

--- a/src/aero_kernel/src/arch/x86_64/interrupts/exceptions.rs
+++ b/src/aero_kernel/src/arch/x86_64/interrupts/exceptions.rs
@@ -69,12 +69,15 @@ pub fn invalid_opcode(stack: &mut InterruptErrorStack) {
     // The RIP on the stack for #UD points to the instruction which generated the exception.
     // The return RIP and RSP need to be changed to the user-provided values in RCX and R11.
     const SYSENTER_OPCODE: [u8; 2] = [0x0f, 0x34];
-    
+
     let opcode = unsafe { *(stack.stack.iret.rip as *const [u8; 2]) };
     if opcode == SYSENTER_OPCODE {
+        log::debug!("handling SYSENTER via #UD");
+
         stack.stack.iret.rip = stack.stack.scratch.rcx;
         stack.stack.iret.rsp = stack.stack.scratch.r11;
 
+        super::super::syscall::x86_64_check_sysenter(stack);
         super::super::syscall::x86_64_do_syscall(stack);
         return;
     }

--- a/src/aero_kernel/src/arch/x86_64/syscall_handler.asm
+++ b/src/aero_kernel/src/arch/x86_64/syscall_handler.asm
@@ -25,8 +25,8 @@ global x86_64_syscall_handler
 %define TSS_TEMP_USTACK_OFF 0x1c
 %define TSS_RSP0_OFF        0x04
 
-%define USERLAND_SS         0x2b
-%define USERLAND_CS         0x33
+%define USERLAND_SS         0x23
+%define USERLAND_CS         0x2b
 
 ; 64-bit SYSCALL instruction entry point. The instruction supports
 ; to to 6 arguments in registers.
@@ -51,7 +51,7 @@ global x86_64_syscall_handler
 ; The instruction also does not save anything on the stack and does
 ; *not* change the RSP.
 x86_64_syscall_handler:
-    ; swap the GS base to ensure that it points to the 
+    ; swap the GS base to ensure that it points to the
     ; kernel PCR.
     swapgs
 

--- a/src/aero_kernel/src/arch/x86_64/task.rs
+++ b/src/aero_kernel/src/arch/x86_64/task.rs
@@ -375,7 +375,11 @@ pub fn arch_task_spinup(from: &mut ArchTask, to: &ArchTask) {
     }
 
     unsafe {
-        super::gdt::get_task_state_segement().rsp[0] = to.context_switch_rsp.as_u64();
+        // Load the new thread's kernel stack pointer everywhere it's needed.
+        let kstackp = to.context_switch_rsp.as_u64();
+        super::gdt::get_task_state_segement().rsp[0] = kstackp;
+        io::wrmsr(io::IA32_SYSENTER_ESP, kstackp);
+
         task_spinup(&mut from.context, to.context.as_ref());
 
         // make a restore point for the current FS base.

--- a/src/aero_kernel/src/utils/io.rs
+++ b/src/aero_kernel/src/utils/io.rs
@@ -39,6 +39,10 @@ pub const IA32_LSTAR: u32 = 0xc0000082;
 /// System Call Flag Mask (R/W).
 pub const IA32_FMASK: u32 = 0xc0000084;
 
+pub const IA32_SYSENTER_CS: u32 = 0x174;
+pub const IA32_SYSENTER_ESP: u32 = 0x175;
+pub const IA32_SYSENTER_EIP: u32 = 0x176;
+
 /// APIC Location and Status (R/W).
 ///
 /// ```text

--- a/userland/apps/utest/src/main.rs
+++ b/userland/apps/utest/src/main.rs
@@ -317,6 +317,23 @@ fn rpc_test() -> Result<(), AeroSyscallError> {
 
 #[utest_proc::test]
 fn sysenter_test() -> Result<(), AeroSyscallError> {
+    let pid = sys_fork()?;
+
+    if pid == 0 {
+        unsafe {
+            core::arch::asm! {
+                "sysenter",
+                in("rcx") 0xf0f0usize << 48,
+                in("r11") 0x0f0fusize << 48,
+            }
+        }
+
+        core::unreachable!();
+    } else {
+        let mut status = 0;
+        sys_waitpid(pid, &mut status, 0)?;
+    }
+
     let msg = "sysenter works!\n";
     let ptr = msg.as_ptr();
     let len = msg.len();


### PR DESCRIPTION
In Long Mode, this is only natively supported by Intel processors, on AMD a #UD exception is generated which is caught in the exception handler to process the system call.

The calling convention uses the same registers as for `syscall`, but since no state is saved with `sysenter`, the caller must
provide the return RIP and RSP in RCX and R11 (the same registers clobbered by a `syscall`).

A typical use would look like this:

```nasm
    lea     rcx, [.return]
    mov     r11, rsp
    sysenter
.return:
```