### PR TITLE
kernel: Implement a syscall proc macro

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "aero_kernel"
 version = "0.1.0"
 dependencies = [
+ "aero_proc",
  "aero_syscall",
  "aero_test",
  "aml",
@@ -24,6 +25,15 @@ dependencies = [
  "stivale-boot",
  "vte",
  "xmas-elf",
+]
+
+[[package]]
+name = "aero_proc"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -279,18 +289,18 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -390,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/aero_kernel/Cargo.toml
+++ b/src/aero_kernel/Cargo.toml
@@ -44,8 +44,11 @@ features = ["no_std"]
 version = "1.4.0"
 features = ["spin_no_std"]
 
+[dependencies.aero_proc]
+path = "../aero_proc"
+
 [dependencies.aero_syscall]
-path = "../aero_syscall/"
+path = "../aero_syscall"
 
 [dependencies.cpio_reader]
 git = "https://github.com/czapek1337/cpio_reader"

--- a/src/aero_kernel/src/syscall/fs.rs
+++ b/src/aero_kernel/src/syscall/fs.rs
@@ -238,9 +238,7 @@ pub fn seek(fd: usize, offset: usize, whence: usize) -> Result<usize, AeroSyscal
 }
 
 #[aero_proc::syscall]
-pub fn pipe(fds: &mut [usize], flags: usize) -> Result<usize, AeroSyscallError> {
-    assert!(fds.len() == 2);
-
+pub fn pipe(fds: &mut [usize; 2], flags: usize) -> Result<usize, AeroSyscallError> {
     let flags = OpenFlags::from_bits(flags).ok_or(AeroSyscallError::EINVAL)?;
     let pipe = Pipe::new();
 

--- a/src/aero_kernel/src/syscall/mod.rs
+++ b/src/aero_kernel/src/syscall/mod.rs
@@ -189,13 +189,12 @@ pub fn generic_do_syscall(
         SYS_GETDENTS => fs::getdents(b, c, d),
         SYS_GETCWD => fs::getcwd(b, c),
         SYS_CHDIR => fs::chdir(b, c),
-        SYS_MKDIR => fs::mkdir(b, c),
         SYS_MKDIR_AT => fs::mkdirat(b, c, d),
         SYS_RMDIR => fs::rmdir(b, c),
         SYS_IOCTL => fs::ioctl(b, c, d),
         SYS_SEEK => fs::seek(b, c, d),
         SYS_ACCESS => fs::access(b, c, d, e, f),
-        SYS_PIPE => fs::pipe(b, c),
+        SYS_PIPE => fs::pipe(b, 2, c), // TODO: We shouldn't have to pass 2 here.
         SYS_UNLINK => fs::unlink(b, c, d, e),
         SYS_DUP => fs::dup(b, c),
         SYS_DUP2 => fs::dup2(b, c, d),
@@ -214,6 +213,9 @@ pub fn generic_do_syscall(
         SYS_IPC_RECV => ipc::recv(b, c, d, e),
         SYS_IPC_DISCOVER_ROOT => ipc::discover_root(),
         SYS_IPC_BECOME_ROOT => ipc::become_root(),
+
+        // Syscall aliases (this should be handled in aero_syscall)
+        SYS_MKDIR => fs::mkdirat(aero_syscall::AT_FDCWD as _, c, d),
 
         _ => {
             log::error!("invalid syscall: {:#x}", a);

--- a/src/aero_kernel/src/syscall/mod.rs
+++ b/src/aero_kernel/src/syscall/mod.rs
@@ -194,7 +194,7 @@ pub fn generic_do_syscall(
         SYS_IOCTL => fs::ioctl(b, c, d),
         SYS_SEEK => fs::seek(b, c, d),
         SYS_ACCESS => fs::access(b, c, d, e, f),
-        SYS_PIPE => fs::pipe(b, 2, c), // TODO: We shouldn't have to pass 2 here.
+        SYS_PIPE => fs::pipe(b, c),
         SYS_UNLINK => fs::unlink(b, c, d, e),
         SYS_DUP => fs::dup(b, c),
         SYS_DUP2 => fs::dup2(b, c, d),

--- a/src/aero_kernel/src/syscall/net.rs
+++ b/src/aero_kernel/src/syscall/net.rs
@@ -2,6 +2,7 @@ use aero_syscall::*;
 
 use crate::{fs::inode::DirEntry, socket::unix::*, userland::scheduler};
 
+#[aero_proc::syscall]
 pub fn socket(
     domain: usize,
     socket_type: usize,
@@ -30,6 +31,8 @@ pub fn socket(
     Ok(fd)
 }
 
+// TODO: Figure out how to handle this.
+#[aero_proc::syscall]
 pub fn bind(fd: usize, address: usize, length: usize) -> Result<usize, AeroSyscallError> {
     let address = unsafe { &*(address as *const SocketAddr) };
     let current_task = scheduler::get_scheduler().current_task();

--- a/src/aero_kernel/src/syscall/time.rs
+++ b/src/aero_kernel/src/syscall/time.rs
@@ -17,17 +17,16 @@
  * along with Aero. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use aero_syscall::AeroSyscallError;
+use aero_syscall::{AeroSyscallError, TimeSpec};
 
+use crate::userland::scheduler;
 use crate::utils::CeilDiv;
-use crate::{mem::paging::VirtAddr, userland::scheduler};
 
 const CLOCK_TYPE_REALTIME: usize = 0;
 const CLOCK_TYPE_MONOTONIC: usize = 1;
 
-pub fn sleep(timespec: usize) -> Result<usize, AeroSyscallError> {
-    let timespec = VirtAddr::new(timespec as u64);
-    let timespec = unsafe { &*(timespec.as_mut_ptr::<aero_syscall::TimeSpec>()) };
+#[aero_proc::syscall]
+pub fn sleep(timespec: &TimeSpec) -> Result<usize, AeroSyscallError> {
     let duration = (timespec.tv_nsec as usize).ceil_div(1000000000) + timespec.tv_sec as usize;
 
     scheduler::get_scheduler().inner.sleep(Some(duration))?;
@@ -35,10 +34,8 @@ pub fn sleep(timespec: usize) -> Result<usize, AeroSyscallError> {
     Ok(0x00)
 }
 
-pub fn gettime(clock: usize, timespec: usize) -> Result<usize, AeroSyscallError> {
-    let timespec = VirtAddr::new(timespec as u64);
-    let timespec = unsafe { &mut *(timespec.as_mut_ptr::<aero_syscall::TimeSpec>()) };
-
+#[aero_proc::syscall]
+pub fn gettime(clock: usize, timespec: &mut TimeSpec) -> Result<usize, AeroSyscallError> {
     match clock {
         CLOCK_TYPE_REALTIME => {
             let clock = crate::time::get_realtime_clock();

--- a/src/aero_kernel/src/utils/mod.rs
+++ b/src/aero_kernel/src/utils/mod.rs
@@ -27,6 +27,22 @@ pub mod io;
 pub mod linker;
 pub mod sync;
 
+pub fn validate_ptr<T>(ptr: *const T) -> Option<&'static T> {
+    if ptr.is_null() {
+        None
+    } else {
+        unsafe { Some(&*ptr) }
+    }
+}
+
+pub fn validate_mut_ptr<T>(ptr: *mut T) -> Option<&'static mut T> {
+    if ptr.is_null() {
+        None
+    } else {
+        unsafe { Some(&mut *ptr) }
+    }
+}
+
 pub fn validate_slice<T>(ptr: *const T, len: usize) -> Option<&'static [T]> {
     if len == 0 {
         Some(&[])

--- a/src/aero_kernel/src/utils/mod.rs
+++ b/src/aero_kernel/src/utils/mod.rs
@@ -68,6 +68,14 @@ pub fn validate_str(ptr: *const u8, len: usize) -> Option<&'static str> {
     }
 }
 
+pub fn validate_array_mut<T, const COUNT: usize>(ptr: *mut T) -> Option<&'static mut [T; COUNT]> {
+    // We use the `validate_slice_mut` function to validate if it safe to read `COUNT` amount
+    // of memory from `ptr`. Then we convert the slice to an array.
+    let slice = validate_slice_mut::<T>(ptr, COUNT);
+    // SAFETY: We know that `slice` is a valid slice of `COUNT` elements.
+    slice.map(|e| unsafe { &mut *(e.as_ptr() as *mut [T; COUNT]) })
+}
+
 pub macro intel_asm($($code:expr,)+) {
    core::arch::global_asm!(concat!($($code),+,));
 }

--- a/src/aero_proc/Cargo.toml
+++ b/src/aero_proc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aero_proc"
+version = "0.1.0"
+authors = ["czapek1337 <czapek1337@gmail.com>"]
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+
+[dependencies.syn]
+features = ["full"]
+version = "1.0.91"

--- a/src/aero_proc/src/lib.rs
+++ b/src/aero_proc/src/lib.rs
@@ -14,6 +14,11 @@ enum ArgType {
     Path,
 }
 
+/// Validates input buffers, structures, path and strings auto-magically.
+///
+/// Functions that use this macro are not allowed to be `async`, `unsafe`, or `const` and must
+/// have a valid return-type of `Result<usize, AeroSyscallError>`. In addition, the function cannot
+/// have generic parameters.
 #[proc_macro_attribute]
 pub fn syscall(_: TokenStream, item: TokenStream) -> TokenStream {
     let parsed_fn = syn::parse_macro_input!(item as syn::ItemFn);

--- a/src/aero_proc/src/lib.rs
+++ b/src/aero_proc/src/lib.rs
@@ -1,0 +1,291 @@
+#![feature(proc_macro_diagnostic, proc_macro_span)]
+
+use proc_macro::{Diagnostic, Level, TokenStream};
+use proc_macro2::{Ident, Span};
+use quote::quote;
+use syn::{punctuated::Punctuated, spanned::Spanned, Expr, FnArg, Lit, Pat, Type};
+
+enum ArgType {
+    Array(bool, usize),
+    Slice(bool),
+    Pointer(bool),
+    Reference(bool),
+    String,
+    Path,
+}
+
+#[proc_macro_attribute]
+pub fn syscall(_: TokenStream, item: TokenStream) -> TokenStream {
+    let parsed_fn = syn::parse_macro_input!(item as syn::ItemFn);
+
+    if let Some(constness) = parsed_fn.sig.constness {
+        Diagnostic::spanned(
+            constness.span().unwrap(),
+            Level::Error,
+            "syscall functions cannot be const",
+        )
+        .emit();
+    }
+
+    if let Some(asyncness) = parsed_fn.sig.asyncness {
+        Diagnostic::spanned(
+            asyncness.span().unwrap(),
+            Level::Error,
+            "syscall functions cannot be async",
+        )
+        .emit();
+    }
+
+    if let Some(unsafety) = parsed_fn.sig.unsafety {
+        Diagnostic::spanned(
+            unsafety.span().unwrap(),
+            Level::Error,
+            "syscall functions cannot be unsafe",
+        )
+        .emit();
+    }
+
+    if let Some(_) = parsed_fn.sig.generics.lt_token {
+        let lt_span = parsed_fn.sig.generics.lt_token.span().unwrap();
+        let gt_span = parsed_fn.sig.generics.gt_token.span().unwrap();
+
+        Diagnostic::spanned(
+            lt_span.join(gt_span).unwrap(),
+            Level::Error,
+            "syscall functions cannot have generic parameters",
+        )
+        .emit();
+    }
+
+    let attrs = &parsed_fn.attrs;
+    let vis = &parsed_fn.vis;
+    let name = &parsed_fn.sig.ident;
+    let orig_args = &parsed_fn.sig.inputs;
+    let processed_args = process_args(orig_args);
+    let call_args = process_call_args(orig_args);
+    let ret = &parsed_fn.sig.output;
+    let body = &parsed_fn.block;
+
+    let result = quote! {
+        #(#attrs)* #vis fn #name(#(#processed_args),*) #ret {
+            #(#attrs)* fn inner_syscall(#orig_args) #ret {
+                #body
+            }
+
+            inner_syscall(#(#call_args),*)
+        }
+    };
+
+    result.into()
+}
+
+fn determine_arg_type(typ: &Type) -> Option<ArgType> {
+    match typ {
+        Type::Reference(typ) => match typ.elem.as_ref() {
+            Type::Array(array) => match &array.len {
+                Expr::Lit(lit) => match &lit.lit {
+                    Lit::Int(lit) => match lit.base10_parse() {
+                        Ok(len) => Some(ArgType::Array(typ.mutability.is_some(), len)),
+                        Err(err) => {
+                            Diagnostic::spanned(
+                                lit.span().unwrap(),
+                                Level::Error,
+                                &format!("failed to parse array length: {}", err),
+                            )
+                            .emit();
+
+                            // If we can't parse the array length, we just give it an arbitrary length.
+                            // This is probably not the best way to do this, but it won't cause any
+                            // further errors to be emitted.
+                            Some(ArgType::Array(typ.mutability.is_some(), 0))
+                        }
+                    },
+                    _ => {
+                        Diagnostic::spanned(
+                            lit.span().unwrap(),
+                            Level::Error,
+                            "array length must be a constant integer",
+                        )
+                        .emit();
+
+                        // Same as above.
+                        Some(ArgType::Array(typ.mutability.is_some(), 0))
+                    }
+                },
+                _ => {
+                    Diagnostic::spanned(
+                        array.span().unwrap(),
+                        Level::Error,
+                        "array length must be a constant integer",
+                    )
+                    .emit();
+
+                    // Same as above.
+                    Some(ArgType::Array(typ.mutability.is_some(), 0))
+                }
+            },
+            Type::Slice(_) => Some(ArgType::Slice(typ.mutability.is_some())),
+            Type::Path(path) => {
+                if path.path.segments.last().unwrap().ident == "str" {
+                    Some(ArgType::String)
+                } else if path.path.segments.last().unwrap().ident == "Path" {
+                    // NOTE: This will match to any type that has the name "Path"
+                    Some(ArgType::Path)
+                } else {
+                    Some(ArgType::Reference(typ.mutability.is_some()))
+                }
+            }
+            _ => None,
+        },
+        Type::Ptr(typ) => Some(ArgType::Pointer(typ.mutability.is_some())),
+        _ => None,
+    }
+}
+
+fn process_args(args: &Punctuated<FnArg, syn::Token![,]>) -> Vec<FnArg> {
+    let mut result = Vec::new();
+
+    for arg in args {
+        match arg {
+            FnArg::Typed(arg) => match arg.pat.as_ref() {
+                Pat::Ident(pat) => {
+                    let attrs = &arg.attrs;
+                    let typ = &arg.ty;
+                    let ident = &pat.ident;
+
+                    match determine_arg_type(typ) {
+                        Some(ArgType::Slice(_) | ArgType::String | ArgType::Path) => {
+                            let data = Ident::new(&format!("{}_data", ident), Span::call_site());
+                            let len = Ident::new(&format!("{}_len", ident), Span::call_site());
+
+                            result.push(syn::parse_quote!(#data: usize));
+                            result.push(syn::parse_quote!(#len: usize));
+                        }
+                        Some(ArgType::Array(_, _)) => {
+                            let data = Ident::new(&format!("{}_data", ident), Span::call_site());
+
+                            result.push(syn::parse_quote!(#data: usize));
+                        }
+                        Some(ArgType::Pointer(_)) | Some(ArgType::Reference(_)) => {
+                            result.push(syn::parse_quote!(#(#attrs)* #ident: usize));
+                        }
+                        None => {
+                            result.push(syn::parse_quote!(#(#attrs)* #ident: #typ));
+                        }
+                    };
+                }
+                _ => {
+                    Diagnostic::spanned(
+                        arg.span().unwrap(),
+                        Level::Error,
+                        "syscall function arguments cannot have non-ident patterns",
+                    )
+                    .emit();
+                }
+            },
+            FnArg::Receiver(_) => {
+                Diagnostic::spanned(
+                    arg.span().unwrap(),
+                    Level::Error,
+                    "syscall functions cannot have receiver arguments",
+                )
+                .emit();
+            }
+        }
+    }
+
+    result
+}
+
+fn process_call_args(args: &Punctuated<FnArg, syn::Token![,]>) -> Vec<Expr> {
+    let mut result = Vec::new();
+
+    for arg in args {
+        match arg {
+            FnArg::Typed(arg) => match arg.pat.as_ref() {
+                Pat::Ident(pat) => {
+                    let ty = &arg.ty;
+                    let ident = &pat.ident;
+
+                    if let Some(arg_type) = determine_arg_type(ty) {
+                        let data_ident = Ident::new(&format!("{}_data", ident), Span::call_site());
+                        let len_ident = Ident::new(&format!("{}_len", ident), Span::call_site());
+
+                        match arg_type {
+                            ArgType::Slice(is_mut) => {
+                                let slice_expr: Expr = if is_mut {
+                                    syn::parse_quote! {
+                                        crate::utils::validate_slice_mut(#data_ident as *mut _, #len_ident).ok_or(AeroSyscallError::EINVAL)?
+                                    }
+                                } else {
+                                    syn::parse_quote! {
+                                        crate::utils::validate_slice(#data_ident as *const _, #len_ident).ok_or(AeroSyscallError::EINVAL)?
+                                    }
+                                };
+
+                                result.push(slice_expr);
+                            }
+                            ArgType::Array(is_mut, length) => {
+                                let array_expr: Expr = if is_mut {
+                                    syn::parse_quote! {
+                                        {
+                                            let slice = crate::utils::validate_slice_mut(#data_ident as *mut _, #length).ok_or(AeroSyscallError::EINVAL)?;
+                                            &mut slice[0..#length]
+                                        }
+                                    }
+                                } else {
+                                    syn::parse_quote! {
+                                        {
+                                            let slice = crate::utils::validate_slice(#data_ident as *const _, #length).ok_or(AeroSyscallError::EINVAL)?;
+                                            &slice[0..#length]
+                                        }
+                                    }
+                                };
+
+                                result.push(array_expr);
+                            }
+                            ArgType::Pointer(is_mut) => {
+                                let ptr_expr: Expr = if is_mut {
+                                    syn::parse_quote!(#ident as *mut _)
+                                } else {
+                                    syn::parse_quote!(#ident as *const _)
+                                };
+
+                                result.push(ptr_expr);
+                            }
+                            ArgType::Reference(is_mut) => {
+                                let ref_expr: Expr = if is_mut {
+                                    syn::parse_quote!({
+                                        crate::utils::validate_mut_ptr(#ident as *mut _).ok_or(AeroSyscallError::EINVAL)?
+                                    })
+                                } else {
+                                    syn::parse_quote!({
+                                        crate::utils::validate_ptr(#ident as *const _).ok_or(AeroSyscallError::EINVAL)?
+                                    })
+                                };
+
+                                result.push(ref_expr);
+                            }
+                            ArgType::String => result.push(syn::parse_quote! {
+                                crate::utils::validate_str(#data_ident as *const _, #len_ident).ok_or(AeroSyscallError::EINVAL)?
+                            }),
+                            ArgType::Path => result.push(syn::parse_quote! {
+                                {
+                                    let string = crate::utils::validate_str(#data_ident as *const _, #len_ident).ok_or(AeroSyscallError::EINVAL)?;
+                                    let path = Path::new(string);
+                                    path
+                                }
+                            }),
+                        }
+                    } else {
+                        result.push(syn::parse_quote!(#ident));
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    result
+}


### PR DESCRIPTION
This patch introduces a procedural macro that takes care of validating input buffers and paths automagically for us :^) There is still a bit of clean up to do, but for the most part it does what it's supposed to be doing.