### PR TITLE
Fix doomgeneric patch DG_SleepMs

### DIFF
--- a/patches/doomgeneric/doomgeneric.patch
+++ b/patches/doomgeneric/doomgeneric.patch
@@ -630,7 +630,7 @@ index 0000000..1172db3
 +    handle_keyboard_input();
 +}
 +
-+void DG_SleepMs(uint32_t ms) { usleep(ms * 1000000); }
++void DG_SleepMs(uint32_t ms) { usleep(ms * 1000); }
 +
 +uint32_t DG_GetTicksMs() {
 +    struct timeval tp;


### PR DESCRIPTION
This PR fixes the conversion from milliseconds to microseconds, unless I'm just really bad at math.

Vinix also seems to get this wrong (I'm guessing Andy yoinked part of the doomgeneric patch from Vinix), I'll PR there too if this PR gets approved (thus confirming that I'm not just really stupid).