### PR TITLE
drm: change the name of rawfb to simpledrm

### DIFF
--- a/src/aero_kernel/src/drivers/drm/mod.rs
+++ b/src/aero_kernel/src/drivers/drm/mod.rs
@@ -17,7 +17,7 @@
  * along with Aero. If not, see <https://www.gnu.org/licenses/>.
  */
 
-mod rawfb;
+mod simpledrm;
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/aero_kernel/src/drivers/drm/simpledrm.rs
+++ b/src/aero_kernel/src/drivers/drm/simpledrm.rs
@@ -86,11 +86,11 @@ impl DrmDevice for RawFramebuffer {
     }
 
     fn driver_info(&self) -> (&'static str, &'static str, &'static str) {
-        ("rawfb_gpu", "rawfb gpu", "0")
+        ("simpledrm", "simpledrm", "0")
     }
 
     fn min_dim(&self) -> (usize, usize) {
-        // NOTE: for rawfb drm device, the max and min dimensions are the same.
+        // NOTE: for simpledrm drm device, the max and min dimensions are the same.
         self.max_dim()
     }
 


### PR DESCRIPTION
In the case of a program or library that checks for the simpledrm
driver from linux change the name of rawfb to simpledrm to
accommodate it.

Signed-off-by: Yusuf Khan <yusisamerican@gmail.com>
---