### PR TITLE
misc(kernel): use load fence before swapgs

### DIFF
--- a/src/aero_kernel/src/arch/x86_64/interrupts/handlers.asm
+++ b/src/aero_kernel/src/arch/x86_64/interrupts/handlers.asm
@@ -39,6 +39,7 @@ interrupt_handler_%1:
     test qword [rsp + 16], 0x3
     ; skip the SWAPGS instruction if CS & 0b11 == 0b00.
     jz .dont_swapgs
+    lfence
     swapgs
     .dont_swapgs:
 
@@ -70,6 +71,7 @@ interrupt_handler_%1:
     test qword [rsp + 8], 0x3
     ; skip the SWAPGS instruction if CS & 0b11 == 0b00.
     jz .dont_swapgs_again
+    lfence
     swapgs
     .dont_swapgs_again:
     


### PR DESCRIPTION
Avoid potential speculative execution issues with swapgs, such as swapgs being speculatively missed.